### PR TITLE
Serve repo line counts dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ npm start -- --repo path/to/repo
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser.
+You can view line counts at `/lines.html`.

--- a/public/lines.html
+++ b/public/lines.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Line Counts</title>
+    <style>
+      svg {
+        font-family: sans-serif;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>File Line Counts</h1>
+    <svg id="chart"></svg>
+    <script type="module">
+      import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
+
+      const data = await fetch('/api/lines').then((res) => res.json());
+
+      const barHeight = 20;
+      const margin = { left: 200, right: 20, top: 20, bottom: 20 };
+      const width = 800;
+      const height = barHeight * data.length + margin.top + margin.bottom;
+
+      const svg = d3
+        .select('#chart')
+        .attr('width', width)
+        .attr('height', height);
+
+      const x = d3
+        .scaleLinear()
+        .domain([0, d3.max(data, (d) => d.lines)])
+        .range([0, width - margin.left - margin.right]);
+
+      const g = svg
+        .append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+      g.selectAll('rect')
+        .data(data)
+        .join('rect')
+        .attr('y', (_, i) => i * barHeight)
+        .attr('width', (d) => x(d.lines))
+        .attr('height', barHeight - 1)
+        .attr('fill', 'steelblue');
+
+      g.selectAll('text')
+        .data(data)
+        .join('text')
+        .attr('x', -5)
+        .attr('y', (_, i) => i * barHeight + (barHeight - 1) / 2)
+        .attr('dy', '0.35em')
+        .attr('text-anchor', 'end')
+        .text((d) => d.file);
+    </script>
+  </body>
+</html>

--- a/src/__tests__/lineCounts.test.ts
+++ b/src/__tests__/lineCounts.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as git from 'isomorphic-git';
+import { getLineCounts } from '../lineCounts';
+
+const author = { name: 'a', email: 'a@example.com' };
+
+describe('getLineCounts', () => {
+  it('counts lines in repo', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), '1\n2\n');
+    await git.add({ fs, dir, filepath: 'a.txt' });
+    await git.commit({ fs, dir, author, message: 'init' });
+
+    const counts = await getLineCounts({ dir, ref: 'HEAD' });
+    expect(counts.find((c) => c.file === 'a.txt')?.lines).toBe(2);
+  });
+});

--- a/src/lineCounts.ts
+++ b/src/lineCounts.ts
@@ -1,0 +1,26 @@
+import * as git from 'isomorphic-git';
+import fs from 'fs';
+
+export interface LineCount {
+  file: string;
+  lines: number;
+}
+
+export const getLineCounts = async ({
+  dir,
+  ref,
+}: {
+  dir: string;
+  ref: string;
+}): Promise<LineCount[]> => {
+  const oid = await git.resolveRef({ fs, dir, ref });
+  const files = await git.listFiles({ fs, dir, ref });
+  const counts: LineCount[] = [];
+  for (const file of files) {
+    const { blob } = await git.readBlob({ fs, dir, oid, filepath: file });
+    const content = Buffer.from(blob).toString('utf8').trimEnd();
+    counts.push({ file, lines: content.split(/\r?\n/).length });
+  }
+  counts.sort((a, b) => b.lines - a.lines);
+  return counts;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import * as git from 'isomorphic-git';
 import fs from 'fs';
 import { Command } from 'commander';
 import path from 'path';
+import { getLineCounts, LineCount } from './lineCounts';
 
 const program = new Command();
 program
@@ -39,6 +40,8 @@ if (!branch) {
   process.exit(1);
 }
 
+const lineCounts: LineCount[] = await getLineCounts({ dir: repoDir, ref: branch });
+
 const app = express();
 
 app.use(express.static('public'));
@@ -50,6 +53,10 @@ app.get('/api/commits', async (_, res) => {
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });
   }
+});
+
+app.get('/api/lines', (_, res) => {
+  res.json(lineCounts);
 });
 
 app.listen(port, host, () => {


### PR DESCRIPTION
## Summary
- remove manual line count script
- add `getLineCounts` helper using isomorphic-git
- expose `/api/lines` endpoint on the server
- update line-count visualization to fetch from the API
- document new workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d9cf21670832aab836cc203d19aeb