### PR TITLE
feat(main): add line count visualization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
       </select>
     </div>
     <ul id="commits"></ul>
+    <svg id="lines-chart"></svg>
     <script type="module" src="./client.js"></script>
   </body>
 </html>

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { fetchLineCounts, renderLineChart } from '../client/lines';
+import type { LineCount } from '../client/types';
+
+describe('lines module', () => {
+  it('fetches line counts with timestamp', async () => {
+    const json = jest.fn().mockResolvedValue([{ file: 'a', lines: 1 }] as LineCount[]);
+    await expect(fetchLineCounts(json, 100)).resolves.toEqual([{ file: 'a', lines: 1 }]);
+    expect(json).toHaveBeenCalledWith('/api/lines?ts=100');
+  });
+
+  it('renders bar chart', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const data: LineCount[] = [{ file: 'a', lines: 1 }];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chain = (): any => ({
+      selectAll: jest.fn(() => chain()),
+      data: jest.fn(() => chain()),
+      join: jest.fn(() => chain()),
+      append: jest.fn(() => chain()),
+      attr: jest.fn(() => chain()),
+      text: jest.fn(() => chain()),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const svgSel: any = { selectAll: jest.fn(() => ({ remove: jest.fn() })), attr: jest.fn(() => svgSel), append: jest.fn(() => chain()) };
+    const d3 = {
+      select: jest.fn(() => svgSel as unknown as ReturnType<typeof chain>),
+      scaleLinear: jest.fn(() => ({ domain: jest.fn(() => ({ range: jest.fn() })) })),
+      max: jest.fn(() => 1),
+    } as unknown as import('../client/lines').D3;
+    renderLineChart(d3, svg, data);
+    expect(d3.select).toHaveBeenCalledWith(svg);
+  });
+});

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -60,4 +60,41 @@ describe('createPlayer', () => {
   expect(seek.value).toBe('5');
   expect(playButton.textContent).toBe('Play');
   });
+
+  it('dispatches input events during playback', () => {
+    document.body.innerHTML = `
+      <button id="play"></button>
+      <input id="seek" />
+      <select id="speed"><option value="1">1x</option></select>
+    `;
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const speed = document.getElementById('speed') as HTMLSelectElement;
+    speed.value = '1';
+
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback) => {
+      callbacks.push(cb);
+      return 1;
+    };
+
+    const listener = jest.fn();
+    seek.addEventListener('input', listener);
+
+    const player = createPlayer({
+      seek,
+      speed,
+      playButton,
+      start: 0,
+      end: 2,
+      raf,
+      now: () => 0,
+    });
+
+    player.togglePlay();
+    callbacks[0]?.(0);
+    callbacks[1]?.(1);
+
+    expect(listener).toHaveBeenCalled();
+  });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
 import { fetchCommits, renderCommitList } from './commits';
 import { createPlayer } from './player';
+import { fetchLineCounts, renderLineChart } from './lines';
 
 const commits = await fetchCommits(d3.json);
 
@@ -11,6 +12,15 @@ const seek = document.getElementById('seek') as HTMLInputElement;
 const speed = document.getElementById('speed') as HTMLSelectElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const list = document.getElementById('commits') as HTMLUListElement;
+const chart = document.getElementById('lines-chart') as SVGSVGElement;
+
+const updateLines = async () => {
+  const counts = await fetchLineCounts(d3.json, Number(seek.value));
+  renderLineChart(d3, chart, counts);
+};
+
+seek.addEventListener('input', updateLines);
 
 createPlayer({ seek, speed, playButton, start, end });
 renderCommitList(list, commits);
+updateLines();

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,0 +1,52 @@
+import type { LineCount } from './types';
+export type D3 = typeof import('d3');
+
+export const fetchLineCounts = async (
+  json: (input: string) => Promise<unknown>,
+  timestamp?: number,
+): Promise<LineCount[]> => {
+  const url = timestamp ? `/api/lines?ts=${timestamp}` : '/api/lines';
+  return (await json(url)) as LineCount[];
+};
+
+export const renderLineChart = (
+  d3: D3,
+  element: SVGSVGElement,
+  data: LineCount[],
+): void => {
+  const svg = d3.select(element);
+  svg.selectAll('*').remove();
+
+  const barHeight = 20;
+  const margin = { left: 200, right: 20, top: 20, bottom: 20 };
+  const width = 800;
+  const height = barHeight * data.length + margin.top + margin.bottom;
+
+  svg.attr('width', width).attr('height', height);
+
+  const x = d3
+    .scaleLinear()
+    .domain([0, d3.max(data, (d) => d.lines) ?? 0])
+    .range([0, width - margin.left - margin.right]);
+
+  const g = svg
+    .append('g')
+    .attr('transform', `translate(${margin.left},${margin.top})`);
+
+  g.selectAll('rect')
+    .data(data)
+    .join('rect')
+    .attr('y', (_, i) => i * barHeight)
+    .attr('width', (d) => x(d.lines))
+    .attr('height', barHeight - 1)
+    .attr('fill', 'steelblue');
+
+  g.selectAll('text')
+    .data(data)
+    .join('text')
+    .attr('x', -5)
+    .attr('y', (_, i) => i * barHeight + (barHeight - 1) / 2)
+    .attr('dy', '0.35em')
+    .attr('text-anchor', 'end')
+    .text((d) => d.file);
+};

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -30,6 +30,7 @@ export const createPlayer = ({
     lastTime = time;
     const next = Math.min(Number(seek.value) + dt, end);
     seek.value = String(next);
+    seek.dispatchEvent(new Event('input'));
     if (next < end) {
       raf(tick);
     } else {
@@ -52,6 +53,7 @@ export const createPlayer = ({
   seek.min = String(start);
   seek.max = String(end);
   seek.value = String(start);
+  seek.dispatchEvent(new Event('input'));
 
   return { togglePlay };
 };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,3 +6,8 @@ export interface Commit {
     };
   };
 }
+
+export interface LineCount {
+  file: string;
+  lines: number;
+}


### PR DESCRIPTION
## Summary
- show line counts on the main page
- dispatch `input` events from player
- support timestamp query for `/api/lines`
- add line chart utilities
- test new functionality

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d9f3d36a4832a8e95b02c2d5af0d7