### PR TITLE
Add API layer and e2e tests

### DIFF
--- a/src/__tests__/commits.test.ts
+++ b/src/__tests__/commits.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
-import { renderCommitList, fetchCommits } from '../client/commits';
+import { fetchCommits } from '../client/api';
+import { renderCommitList } from '../client/commits';
 import type { Commit } from '../client/types';
 
 describe('commits module', () => {

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as git from 'isomorphic-git';
+import type { AddressInfo } from 'net';
+import { createApp } from '../app';
+import { fetchCommits, fetchLineCounts, JsonFetcher } from '../client/api';
+
+const author = { name: 'a', email: 'a@example.com' };
+
+const makeJsonFetcher = (port: number): JsonFetcher => {
+  return (input: string) => fetch(`http://localhost:${port}${input}`).then((r) => r.json());
+};
+
+describe('server e2e', () => {
+  it('serves commits and line counts', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), '1\n2\n');
+    await git.add({ fs, dir, filepath: 'a.txt' });
+    await git.commit({ fs, dir, author, message: 'init' });
+
+    const app = await createApp({ repo: dir, branch: 'HEAD' });
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    const json = makeJsonFetcher(port);
+    const commits = await fetchCommits(json);
+    const counts = await fetchLineCounts(json);
+
+    expect(commits[0].commit.message).toBe('init\n');
+    expect(counts[0]?.file).toBe('a.txt');
+
+    server.close();
+  });
+});

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
-import { fetchLineCounts, renderFileSimulation } from '../client/lines';
+import { fetchLineCounts } from '../client/api';
+import { renderFileSimulation } from '../client/lines';
 import type { LineCount } from '../client/types';
 
 describe('lines module', () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import * as git from 'isomorphic-git';
+import fs from 'fs';
+import path from 'path';
+import { getLineCounts, LineCount } from './lineCounts';
+
+export interface CreateAppOptions {
+  repo: string;
+  branch?: string;
+}
+
+export const createApp = async ({ repo, branch: inputBranch }: CreateAppOptions) => {
+  const repoDir = path.resolve(repo);
+  if (!fs.existsSync(path.join(repoDir, '.git'))) {
+    throw new Error(`${repoDir} is not a git repository.`);
+  }
+
+  const branches = await git.listBranches({ fs, dir: repoDir });
+  let branch = inputBranch;
+  if (!branch) {
+    branch = ['main', 'master', 'trunk'].find((b) => branches.includes(b)) ?? branches[0];
+  }
+  if (!branch) {
+    throw new Error('No branch found.');
+  }
+
+  const commits = await git.log({ fs, dir: repoDir, ref: branch });
+  const lineCounts: LineCount[] = await getLineCounts({ dir: repoDir, ref: branch });
+
+  const app = express();
+
+  app.use(express.static('public'));
+
+  app.get('/api/commits', (_, res) => {
+    res.json(commits);
+  });
+
+  app.get('/api/lines', async (req, res) => {
+    const tsParam = req.query.ts as string | undefined;
+    if (tsParam) {
+      const ts = Number(tsParam) / 1000;
+      const commit = commits.find((c) => c.commit.committer.timestamp <= ts);
+      if (!commit) {
+        res.status(404).json({ error: 'Commit not found' });
+        return;
+      }
+      try {
+        const counts = await getLineCounts({ dir: repoDir, ref: commit.oid });
+        res.json(counts);
+      } catch (error) {
+        res.status(500).json({ error: (error as Error).message });
+      }
+    } else {
+      res.json(lineCounts);
+    }
+  });
+
+  return app;
+};

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,0 +1,17 @@
+import type { Commit, LineCount } from './types';
+
+export type JsonFetcher = (input: string) => Promise<unknown>;
+
+export const fetchCommits = async (
+  json: JsonFetcher,
+): Promise<Commit[]> => {
+  return (await json('/api/commits')) as Commit[];
+};
+
+export const fetchLineCounts = async (
+  json: JsonFetcher,
+  timestamp?: number,
+): Promise<LineCount[]> => {
+  const url = timestamp ? `/api/lines?ts=${timestamp}` : '/api/lines';
+  return (await json(url)) as LineCount[];
+};

--- a/src/client/commits.ts
+++ b/src/client/commits.ts
@@ -1,11 +1,5 @@
 import type { Commit } from './types';
 
-export const fetchCommits = async (
-  json: (input: string) => Promise<unknown>,
-): Promise<Commit[]> => {
-  return (await json('/api/commits')) as Commit[];
-};
-
 export const renderCommitList = (
   element: HTMLElement,
   commits: Commit[],

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,7 @@
-import { fetchCommits, renderCommitList } from './commits';
+import { fetchCommits, fetchLineCounts } from './api';
+import { renderCommitList } from './commits';
 import { createPlayer } from './player';
-import { fetchLineCounts, renderFileSimulation } from './lines';
+import { renderFileSimulation } from './lines';
 
 const json = (input: string) => fetch(input).then((r) => r.json());
 const commits = await fetchCommits(json);

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,15 +1,6 @@
 import type { LineCount } from './types';
 import { Bodies, Composite, Engine } from 'matter-js';
 
-export const fetchLineCounts = async (
-  json: (input: string) => Promise<unknown>,
-  timestamp?: number,
-): Promise<LineCount[]> => {
-  const url = timestamp ? `/api/lines?ts=${timestamp}` : '/api/lines';
-  return (await json(url)) as LineCount[];
-};
-
-
 interface BodyInfo {
   el: HTMLElement;
   body: Matter.Body;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,5 @@
-import express from 'express';
-import * as git from 'isomorphic-git';
-import fs from 'fs';
 import { Command } from 'commander';
-import path from 'path';
-import { getLineCounts, LineCount } from './lineCounts';
+import { createApp } from './app';
 
 const program = new Command();
 program
@@ -14,64 +10,14 @@ program
 
 program.parse();
 
-const { repo, host, port, branch: inputBranch } = program.opts<{
+const { repo, host, port, branch } = program.opts<{
   repo: string;
   host: string;
   port: number;
   branch?: string;
 }>();
 
-const repoDir = path.resolve(repo);
-
-if (!fs.existsSync(path.join(repoDir, '.git'))) {
-  console.error(`${repoDir} is not a git repository.`);
-  process.exit(1);
-}
-
-const branches = await git.listBranches({ fs, dir: repoDir });
-let branch = inputBranch;
-if (!branch) {
-  branch =
-    ['main', 'master', 'trunk'].find((b) => branches.includes(b)) ??
-    branches[0];
-}
-if (!branch) {
-  console.error('No branch found.');
-  process.exit(1);
-}
-
-const commits = await git.log({ fs, dir: repoDir, ref: branch });
-const lineCounts: LineCount[] = await getLineCounts({ dir: repoDir, ref: branch });
-
-const app = express();
-
-app.use(express.static('public'));
-
-app.get('/api/commits', (_, res) => {
-  res.json(commits);
-});
-
-app.get('/api/lines', async (req, res) => {
-  const tsParam = req.query.ts as string | undefined;
-  if (tsParam) {
-    const ts = Number(tsParam) / 1000;
-    const commit = commits.find(
-      (c) => c.commit.committer.timestamp <= ts,
-    );
-    if (!commit) {
-      res.status(404).json({ error: 'Commit not found' });
-      return;
-    }
-    try {
-      const counts = await getLineCounts({ dir: repoDir, ref: commit.oid });
-      res.json(counts);
-    } catch (error) {
-      res.status(500).json({ error: (error as Error).message });
-    }
-  } else {
-    res.json(lineCounts);
-  }
-});
+const app = await createApp({ repo, branch });
 
 app.listen(port, host, () => {
   console.log(`Server running at http://${host}:${port}`);


### PR DESCRIPTION
## Summary
- add an Express app factory
- extract client API helpers
- update modules to use the new API layer
- create e2e test with a local Git repo

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684da60d9e78832a99733b7eba20287f