### PR TITLE
feat(server): default repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Install dependencies and start the server:
 npm install
 npm run lint
 npm test
-npm start -- --repo path/to/repo
+npm start                # defaults to current directory
+# npm start -- --repo path/to/repo
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser.

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { createApp } from './app';
 
 const program = new Command();
 program
-  .requiredOption('-r, --repo <path>', 'path to the git repository')
+  .option('-r, --repo <path>', 'path to the git repository', process.cwd())
   .option('-b, --branch <name>', 'branch to inspect')
   .option('-H, --host <host>', 'host name to listen on', 'localhost')
   .option('-p, --port <number>', 'port to listen on', (v) => Number(v), 3000);


### PR DESCRIPTION
## Summary
- allow server repo path to be optional
- document default path in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684da8ee84ac832aa023721292a7d4b1