### PR TITLE
Fix import paths for browser modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 .DS_Store
 /dist
-public/client.js
+public/*.js
 coverage/
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,4 +1,4 @@
-import type { Commit, LineCount } from './types';
+import type { Commit, LineCount } from './types.js';
 
 export type JsonFetcher = (input: string) => Promise<unknown>;
 

--- a/src/client/commits.ts
+++ b/src/client/commits.ts
@@ -1,4 +1,4 @@
-import type { Commit } from './types';
+import type { Commit } from './types.js';
 
 export const renderCommitList = (
   element: HTMLElement,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,7 @@
-import { fetchCommits, fetchLineCounts } from './api';
-import { renderCommitList } from './commits';
-import { createPlayer } from './player';
-import { renderFileSimulation } from './lines';
+import { fetchCommits, fetchLineCounts } from './api.js';
+import { renderCommitList } from './commits.js';
+import { createPlayer } from './player.js';
+import { renderFileSimulation } from './lines.js';
 
 const json = (input: string) => fetch(input).then((r) => r.json());
 const commits = await fetchCommits(json);

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,4 +1,4 @@
-import type { LineCount } from './types';
+import type { LineCount } from './types.js';
 import { Bodies, Composite, Engine } from 'matter-js';
 
 interface BodyInfo {


### PR DESCRIPTION
## Summary
- use explicit `.js` extensions in browser-facing imports
- ignore compiled JS files

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684daa318d80832a892e39495742f64f