### PR TITLE
fix matter-js import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,13 @@
     </div>
     <ul id="commits"></ul>
     <div id="sim" style="width:800px;height:600px;position:relative;overflow:hidden;border:1px solid #ccc"></div>
+    <script type="importmap">
+      {
+        "imports": {
+          "matter-js": "https://cdn.jsdelivr.net/npm/matter-js@0.20.0/build/matter.js"
+        }
+      }
+    </script>
     <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/public/lines.html
+++ b/public/lines.html
@@ -22,6 +22,13 @@
   <body>
     <h1>File Line Counts</h1>
     <div id="sim"></div>
+    <script type="importmap">
+      {
+        "imports": {
+          "matter-js": "https://cdn.jsdelivr.net/npm/matter-js@0.20.0/build/matter.js"
+        }
+      }
+    </script>
     <script type="module">
       import { fetchLineCounts, renderFileSimulation } from './lines.js';
       const json = (u) => fetch(u).then((r) => r.json());


### PR DESCRIPTION
## Summary
- add an import map in `public/index.html` and `public/lines.html` so the browser resolves the `matter-js` module

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dab7bee98832aaf20be6c5b9772c6