### PR TITLE
Fix CDN module error with Matter.js

### DIFF
--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,5 +1,6 @@
 import type { LineCount } from './types.js';
-import { Bodies, Composite, Engine } from 'matter-js';
+import Matter from 'matter-js';
+const { Bodies, Composite, Engine } = Matter;
 
 interface BodyInfo {
   el: HTMLElement;


### PR DESCRIPTION
## Summary
- import Matter as default to work around missing ESM exports

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dac4c0b30832abe3b865276b13fc0