### PR TITLE
fix matter-js import

### DIFF
--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,5 +1,5 @@
 import type { LineCount } from './types.js';
-import Matter from 'matter-js';
+import * as Matter from 'matter-js';
 const { Bodies, Composite, Engine } = Matter;
 
 interface BodyInfo {


### PR DESCRIPTION
## Summary
- use named import for matter-js to avoid missing default export error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dad4cb328832ab548166ad40272ff