### PR TITLE
Adjust playback time scaling

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -24,6 +24,7 @@ const updateLines = async (): Promise<void> => {
 
 seek.addEventListener('input', updateLines);
 
-createPlayer({ seek, speed, playButton, start, end });
+const DAY_MS = 86_400_000; // playback scale: one day per second at 1x
+createPlayer({ seek, speed, playButton, start, end, timeScale: DAY_MS });
 renderCommitList(list, commits);
 updateLines();

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -4,6 +4,11 @@ export interface PlayerOptions {
   playButton: HTMLButtonElement;
   start: number;
   end: number;
+  /**
+   * Multiply the playback delta by this factor. Useful when commit timestamps
+   * span long periods and real-time playback would be too slow.
+   */
+  timeScale?: number;
   raf?: (cb: FrameRequestCallback) => number;
   now?: () => number;
 }
@@ -14,6 +19,7 @@ export const createPlayer = ({
   playButton,
   start,
   end,
+  timeScale = 1,
   raf = requestAnimationFrame,
   now = performance.now,
 }: PlayerOptions) => {
@@ -26,7 +32,7 @@ export const createPlayer = ({
       raf(tick);
       return;
     }
-    const dt = (time - lastTime) * parseFloat(speed.value);
+    const dt = (time - lastTime) * parseFloat(speed.value) * timeScale;
     lastTime = time;
     const next = Math.min(Number(seek.value) + dt, end);
     seek.value = String(next);


### PR DESCRIPTION
## Summary
- add time scaling support to player
- playback now defaults to 1 day per second

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684db839a890832a9b50c8b4cf3ed89b