### PR TITLE
feat: improve playback scale

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -16,7 +16,16 @@ describe('createPlayer', () => {
     const raf = jest.fn();
     const now = jest.fn(() => 0);
 
-    createPlayer({ seek, speed, playButton, start: 0, end: 10, raf, now });
+    createPlayer({
+      seek,
+      speed,
+      playButton,
+      start: 0,
+      end: 10,
+      raf,
+      now,
+      timeScale: 1,
+    });
 
     playButton.click();
     expect(playButton.textContent).toBe('Pause');
@@ -50,6 +59,7 @@ describe('createPlayer', () => {
     end: 5,
     raf,
     now: () => 0,
+    timeScale: 1,
   });
 
   player.togglePlay();
@@ -89,6 +99,7 @@ describe('createPlayer', () => {
       end: 2,
       raf,
       now: () => 0,
+      timeScale: 1,
     });
 
     player.togglePlay();

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -4,6 +4,7 @@ export interface PlayerOptions {
   playButton: HTMLButtonElement;
   start: number;
   end: number;
+  timeScale?: number;
   raf?: (cb: FrameRequestCallback) => number;
   now?: () => number;
 }
@@ -14,6 +15,7 @@ export const createPlayer = ({
   playButton,
   start,
   end,
+  timeScale = 24 * 60 * 60 * 1000,
   raf = requestAnimationFrame,
   now = performance.now,
 }: PlayerOptions) => {
@@ -26,7 +28,7 @@ export const createPlayer = ({
       raf(tick);
       return;
     }
-    const dt = (time - lastTime) * parseFloat(speed.value);
+    const dt = (time - lastTime) * parseFloat(speed.value) * timeScale;
     lastTime = time;
     const next = Math.min(Number(seek.value) + dt, end);
     seek.value = String(next);


### PR DESCRIPTION
## Summary
- accelerate playback by introducing `timeScale` option
- adjust player tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dbc4a1438832a9996b70f4bff102d