### PR TITLE
Add eased scaling for circle simulation

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { fetchLineCounts } from '../client/api';
-import { renderFileSimulation } from '../client/lines';
+import { renderFileSimulation, computeScale } from '../client/lines';
 import type { LineCount } from '../client/types';
 
 describe('lines module', () => {
@@ -36,5 +36,18 @@ describe('lines module', () => {
     callbacks[0]?.(0);
     expect(div.querySelectorAll('.file-circle')).toHaveLength(2);
     stop();
+  });
+
+  it('computes scale with easing', () => {
+    const scale = computeScale(200, 200, [
+      { file: 'a', lines: 1 },
+      { file: 'b', lines: 2 },
+    ]);
+    expect(scale).toBeLessThan(100);
+  });
+
+  it('returns base scale when ratio below threshold', () => {
+    const scale = computeScale(1000, 200, [{ file: 'a', lines: 1 }]);
+    expect(scale).toBe(200);
   });
 });

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -25,6 +25,24 @@ interface BodyInfo {
   r: number;
 }
 
+export const computeScale = (
+  width: number,
+  height: number,
+  data: LineCount[],
+): number => {
+  const maxLines = data.reduce((m, d) => Math.max(m, d.lines), 1);
+  const base = Math.min(width, height) / maxLines;
+  const totalArea = data.reduce(
+    (sum, f) => sum + Math.PI * ((f.lines * base) / 2) ** 2,
+    0,
+  );
+  const ratio = totalArea / (width * height);
+  const threshold = 0.5;
+  if (ratio <= threshold) return base;
+  const easing = Math.pow(threshold / ratio, 0.25);
+  return base * easing;
+};
+
 export const renderFileSimulation = (
   container: HTMLElement,
   data: LineCount[],
@@ -36,8 +54,7 @@ export const renderFileSimulation = (
   const rect = container.getBoundingClientRect();
   const width = rect.width;
   const height = rect.height;
-  const maxLines = data[0]?.lines ?? 1;
-  const scale = Math.min(width, height) / maxLines;
+  const scale = computeScale(width, height, data);
 
   const engine = Engine.create();
   engine.gravity.y = 1;


### PR DESCRIPTION
## Summary
- introduce `computeScale` to adjust scale by total area ratio
- use the new scaling in `renderFileSimulation`
- verify scale behavior in unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dbcc550d4832aa131f416b709a883