### PR TITLE
Fix player performance.now binding

### DIFF
--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -17,7 +17,7 @@ export const createPlayer = ({
   end,
   timeScale = 24 * 60 * 60 * 1000,
   raf = requestAnimationFrame,
-  now = performance.now,
+  now = performance.now.bind(performance),
 }: PlayerOptions) => {
   let playing = false;
   let lastTime = 0;


### PR DESCRIPTION
## Summary
- bind `performance.now` in player default options to ensure correct context

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dbe9b62a8832a9f47bfe8f1ff8ac5