### PR TITLE
Update player to use playback duration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,12 +16,7 @@
     <div id="controls">
       <button id="play">Play</button>
       <input type="range" id="seek" />
-      <select id="speed">
-        <option value="0.5">0.5x</option>
-        <option value="1" selected>1x</option>
-        <option value="2">2x</option>
-        <option value="4">4x</option>
-      </select>
+      <input type="number" id="duration" value="20" min="1" />s
     </div>
     <div id="sim"></div>
     <script type="importmap">

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -6,25 +6,24 @@ describe('createPlayer', () => {
     document.body.innerHTML = `
       <button id="play"></button>
       <input id="seek" />
-      <select id="speed"><option value="1">1x</option></select>
+      <input id="duration" />
     `;
     const playButton = document.getElementById('play') as HTMLButtonElement;
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const speed = document.getElementById('speed') as HTMLSelectElement;
-    speed.value = '1';
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '20';
 
     const raf = jest.fn();
     const now = jest.fn(() => 0);
 
     createPlayer({
       seek,
-      speed,
+      duration,
       playButton,
       start: 0,
       end: 10,
       raf,
       now,
-      timeScale: 1,
     });
 
     playButton.click();
@@ -38,12 +37,12 @@ describe('createPlayer', () => {
     document.body.innerHTML = `
     <button id="play"></button>
     <input id="seek" />
-    <select id="speed"><option value="1">1x</option></select>
+    <input id="duration" />
   `;
   const playButton = document.getElementById('play') as HTMLButtonElement;
   const seek = document.getElementById('seek') as HTMLInputElement;
-  const speed = document.getElementById('speed') as HTMLSelectElement;
-  speed.value = '1';
+  const duration = document.getElementById('duration') as HTMLInputElement;
+  duration.value = '1';
 
   const callbacks: FrameRequestCallback[] = [];
   const raf = (cb: FrameRequestCallback) => {
@@ -53,19 +52,18 @@ describe('createPlayer', () => {
 
   const player = createPlayer({
     seek,
-    speed,
+    duration,
     playButton,
     start: 0,
     end: 5,
     raf,
     now: () => 0,
-    timeScale: 1,
   });
 
   player.togglePlay();
   callbacks[0]?.(0);
-  callbacks[1]?.(1);
-  callbacks[2]?.(6);
+  callbacks[1]?.(500);
+  callbacks[2]?.(1000);
 
   expect(seek.value).toBe('5');
   expect(playButton.textContent).toBe('Play');
@@ -75,12 +73,12 @@ describe('createPlayer', () => {
     document.body.innerHTML = `
       <button id="play"></button>
       <input id="seek" />
-      <select id="speed"><option value="1">1x</option></select>
+      <input id="duration" />
     `;
     const playButton = document.getElementById('play') as HTMLButtonElement;
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const speed = document.getElementById('speed') as HTMLSelectElement;
-    speed.value = '1';
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '1';
 
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback) => {
@@ -93,18 +91,17 @@ describe('createPlayer', () => {
 
     const player = createPlayer({
       seek,
-      speed,
+      duration,
       playButton,
       start: 0,
       end: 2,
       raf,
       now: () => 0,
-      timeScale: 1,
     });
 
     player.togglePlay();
     callbacks[0]?.(0);
-    callbacks[1]?.(1);
+    callbacks[1]?.(1000);
 
     expect(listener).toHaveBeenCalled();
   });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -9,7 +9,7 @@ const start = commits[commits.length - 1].commit.committer.timestamp * 1000;
 const end = commits[0].commit.committer.timestamp * 1000;
 
 const seek = document.getElementById('seek') as HTMLInputElement;
-const speed = document.getElementById('speed') as HTMLSelectElement;
+const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 
@@ -22,5 +22,5 @@ const updateLines = async (): Promise<void> => {
 
 seek.addEventListener('input', updateLines);
 
-createPlayer({ seek, speed, playButton, start, end });
+createPlayer({ seek, duration, playButton, start, end });
 updateLines();

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -1,21 +1,19 @@
 export interface PlayerOptions {
   seek: HTMLInputElement;
-  speed: HTMLSelectElement;
+  duration: HTMLInputElement;
   playButton: HTMLButtonElement;
   start: number;
   end: number;
-  timeScale?: number;
   raf?: (cb: FrameRequestCallback) => number;
   now?: () => number;
 }
 
 export const createPlayer = ({
   seek,
-  speed,
+  duration,
   playButton,
   start,
   end,
-  timeScale = 24 * 60 * 60 * 1000,
   raf = requestAnimationFrame,
   now = performance.now.bind(performance),
 }: PlayerOptions) => {
@@ -28,7 +26,9 @@ export const createPlayer = ({
       raf(tick);
       return;
     }
-    const dt = (time - lastTime) * parseFloat(speed.value) * timeScale;
+    const total = parseFloat(duration.value) * 1000;
+    const factor = (end - start) / total;
+    const dt = (time - lastTime) * factor;
     lastTime = time;
     const next = Math.min(Number(seek.value) + dt, end);
     seek.value = String(next);


### PR DESCRIPTION
## Summary
- replace playback speed selector with duration input
- update player logic to use total playback duration
- adjust tests for new duration setting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dbf983da4832aa01837c8f967cec9