### PR TITLE
Reuse simulation elements

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,6 @@
 import { fetchCommits, fetchLineCounts } from './api.js';
 import { createPlayer } from './player.js';
-import { renderFileSimulation } from './lines.js';
+import { createFileSimulation } from './lines.js';
 
 const json = (input: string) => fetch(input).then((r) => r.json());
 const commits = await fetchCommits(json);
@@ -12,12 +12,11 @@ const seek = document.getElementById('seek') as HTMLInputElement;
 const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
+const { update } = createFileSimulation(sim);
 
-let stop = () => {};
 const updateLines = async (): Promise<void> => {
   const counts = await fetchLineCounts(json, Number(seek.value));
-  stop();
-  stop = renderFileSimulation(sim, counts);
+  update(counts);
 };
 
 seek.addEventListener('input', updateLines);

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -43,54 +43,20 @@ export const computeScale = (
   return base * easing;
 };
 
-export const renderFileSimulation = (
+export const createFileSimulation = (
   container: HTMLElement,
-  data: LineCount[],
   opts: { raf?: (cb: FrameRequestCallback) => number; now?: () => number } = {},
-): (() => void) => {
+) => {
   const raf = opts.raf ?? requestAnimationFrame;
   const now = opts.now ?? performance.now.bind(performance);
-  container.innerHTML = '';
   const rect = container.getBoundingClientRect();
   const width = rect.width;
   const height = rect.height;
-  const scale = computeScale(width, height, data);
-
   const engine = Engine.create();
   engine.gravity.y = 1;
   engine.gravity.scale = 0.001;
 
-  const bodies: BodyInfo[] = [];
-  for (const file of data) {
-    const r = (file.lines * scale) / 2;
-    const el = document.createElement('div');
-    el.className = 'file-circle';
-    el.style.position = 'absolute';
-    el.style.width = `${r * 2}px`;
-    el.style.height = `${r * 2}px`;
-    el.style.borderRadius = '50%';
-    el.style.background = colorForFile(file.file);
-    el.style.willChange = 'transform';
-    const dir = file.file.split('/');
-    const name = dir.pop() ?? '';
-    const pathEl = document.createElement('div');
-    pathEl.className = 'path';
-    pathEl.textContent = dir.join('/') + (dir.length ? '/' : '');
-    const nameEl = document.createElement('div');
-    nameEl.className = 'name';
-    nameEl.textContent = name;
-    el.append(pathEl, nameEl);
-    container.appendChild(el);
-    const body = Bodies.circle(
-      Math.random() * (width - 2 * r) + r,
-      -Math.random() * height - r,
-      r,
-      { restitution: 0.9, frictionAir: 0.01 },
-    );
-    bodies.push({ el, body, r });
-    Composite.add(engine.world, body);
-  }
-
+  const bodies: Record<string, BodyInfo> = {};
   const walls = [
     Bodies.rectangle(width / 2, height + 10, width, 20, { isStatic: true }),
     Bodies.rectangle(-10, height / 2, 20, height, { isStatic: true }),
@@ -98,12 +64,62 @@ export const renderFileSimulation = (
   ];
   Composite.add(engine.world, walls);
 
+  const update = (data: LineCount[]): void => {
+    const scale = computeScale(width, height, data);
+    const names = new Set(data.map((d) => d.file));
+    for (const [name, info] of Object.entries(bodies)) {
+      if (!names.has(name)) {
+        Composite.remove(engine.world, info.body);
+        container.removeChild(info.el);
+        delete bodies[name];
+      }
+    }
+    for (const file of data) {
+      const r = (file.lines * scale) / 2;
+      const existing = bodies[file.file];
+      if (existing) {
+        const factor = r / existing.r;
+        Matter.Body.scale(existing.body, factor, factor);
+        existing.r = r;
+        existing.el.style.width = `${r * 2}px`;
+        existing.el.style.height = `${r * 2}px`;
+      } else {
+        const el = document.createElement('div');
+        el.className = 'file-circle';
+        el.style.position = 'absolute';
+        el.style.width = `${r * 2}px`;
+        el.style.height = `${r * 2}px`;
+        el.style.borderRadius = '50%';
+        el.style.background = colorForFile(file.file);
+        el.style.willChange = 'transform';
+        const dir = file.file.split('/');
+        const name = dir.pop() ?? '';
+        const pathEl = document.createElement('div');
+        pathEl.className = 'path';
+        pathEl.textContent = dir.join('/') + (dir.length ? '/' : '');
+        const nameEl = document.createElement('div');
+        nameEl.className = 'name';
+        nameEl.textContent = name;
+        el.append(pathEl, nameEl);
+        container.appendChild(el);
+        const body = Bodies.circle(
+          Math.random() * (width - 2 * r) + r,
+          -Math.random() * height - r,
+          r,
+          { restitution: 0.9, frictionAir: 0.01 },
+        );
+        bodies[file.file] = { el, body, r };
+        Composite.add(engine.world, body);
+      }
+    }
+  };
+
   let frameId = 0;
   let last = now();
-  const step = (time: number) => {
+  const step = (time: number): void => {
     Engine.update(engine, time - last);
     last = time;
-    for (const { body, el, r } of bodies) {
+    for (const { body, el, r } of Object.values(bodies)) {
       const { x, y } = body.position;
       el.style.transform = `translate3d(${x - r}px, ${y - r}px, 0) rotate(${body.angle}rad)`;
     }
@@ -111,5 +127,17 @@ export const renderFileSimulation = (
   };
 
   frameId = raf(step);
-  return () => cancelAnimationFrame(frameId);
+  const destroy = (): void => cancelAnimationFrame(frameId);
+  return { update, destroy };
+};
+
+export const renderFileSimulation = (
+  container: HTMLElement,
+  data: LineCount[],
+  opts: { raf?: (cb: FrameRequestCallback) => number; now?: () => number } = {},
+): (() => void) => {
+  container.innerHTML = '';
+  const sim = createFileSimulation(container, opts);
+  sim.update(data);
+  return sim.destroy;
 };


### PR DESCRIPTION
## Summary
- reuse DOM/Matter bodies across render updates
- adapt player to new simulation API
- verify element reuse in tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc1e00824832abfc405c3f9fef093