### PR TITLE
Remove tiny circles

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -71,6 +71,31 @@ describe('lines module', () => {
     sim.destroy();
   });
 
+  it('removes circles smaller than 1px', () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 0.5,
+      height: 0.5,
+      top: 0,
+      left: 0,
+      bottom: 0.5,
+      right: 0.5,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback): number => {
+      callbacks.push(cb);
+      return 1;
+    };
+    const sim = createFileSimulation(div, { raf, now: () => 0 });
+    sim.update([{ file: 'a', lines: 1 }]);
+    callbacks[0]?.(0);
+    expect(div.querySelectorAll('.file-circle')).toHaveLength(0);
+    sim.destroy();
+  });
+
   it('computes scale with easing', () => {
     const scale = computeScale(200, 200, [
       { file: 'a', lines: 1 },

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -2,6 +2,8 @@ import type { LineCount } from './types.js';
 import Matter from 'matter-js';
 const { Bodies, Composite, Engine } = Matter;
 
+const MIN_CIRCLE_SIZE = 1;
+
 const fileColors: Record<string, string> = {
   '.ts': '#2b7489',
   '.js': '#f1e05a',
@@ -77,6 +79,14 @@ export const createFileSimulation = (
     for (const file of data) {
       const r = (file.lines * scale) / 2;
       const existing = bodies[file.file];
+      if (r * 2 < MIN_CIRCLE_SIZE) {
+        if (existing) {
+          Composite.remove(engine.world, existing.body);
+          container.removeChild(existing.el);
+          delete bodies[file.file];
+        }
+        continue;
+      }
       if (existing) {
         const factor = r / existing.r;
         Matter.Body.scale(existing.body, factor, factor);


### PR DESCRIPTION
## Summary
- ignore file circles smaller than 1px
- test removal of tiny circles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc3773308832ab3384db8da990f71