### PR TITLE
Add non-linear line scaling

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -101,7 +101,17 @@ describe('lines module', () => {
       { file: 'a', lines: 1 },
       { file: 'b', lines: 2 },
     ]);
-    expect(scale).toBeLessThan(80);
+    expect(scale).toBeLessThan(100);
+  });
+
+  it('supports linear scaling option', () => {
+    const data: LineCount[] = [
+      { file: 'a', lines: 1 },
+      { file: 'b', lines: 2 },
+    ];
+    const nonlinear = computeScale(200, 200, data);
+    const linear = computeScale(200, 200, data, { linear: true });
+    expect(linear).toBeLessThan(nonlinear);
   });
 
   it('returns base scale when ratio below threshold', () => {


### PR DESCRIPTION
## Summary
- tweak circle scale calculation to use square-root scaling by default
- allow callers to opt into linear scaling
- test the new computeScale option

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc98fe664832a82332948da8c091e