### PR TITLE
feat(ui): add commit log overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,44 @@
       body { margin: 0; overflow: hidden; }
       #sim { position: fixed; inset: 0; overflow: hidden; }
       #controls { position: absolute; top: 10px; left: 10px; z-index: 1; }
+      #commit-log {
+        position: fixed;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 250px;
+        padding: 10px;
+        font-family: monospace;
+        color: #fff;
+        pointer-events: none;
+        overflow: hidden;
+        mask-image: linear-gradient(
+          to bottom,
+          transparent,
+          black 20px,
+          black calc(100% - 20px),
+          transparent
+        );
+      }
+      #commit-log ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      #commit-log li.current {
+        color: #0ff;
+      }
+      .commit-marker {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 50%;
+        height: 2px;
+        background: #0ff;
+      }
       .file-circle {
         display: flex;
         flex-direction: column;
@@ -72,6 +110,7 @@
       <input type="number" id="duration" value="20" min="1" />s
     </div>
     <div id="sim"></div>
+    <div id="commit-log"></div>
     <script type="importmap">
       {
         "imports": {

--- a/src/__tests__/commitLog.test.ts
+++ b/src/__tests__/commitLog.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import { createCommitLog } from '../client/commitLog';
+import type { Commit } from '../client/types';
+
+describe('createCommitLog', () => {
+  it('highlights current commit on input', () => {
+    document.body.innerHTML = '<div id="log"></div><input id="seek" />';
+    const container = document.getElementById('log') as HTMLDivElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const commits: Commit[] = [
+      { commit: { message: 'new', committer: { timestamp: 2 } } },
+      { commit: { message: 'old', committer: { timestamp: 1 } } },
+    ];
+    seek.value = '1500';
+    const { render } = createCommitLog({ container, seek, commits, visible: 2 });
+    let current = container.querySelector('li.current')?.textContent;
+    expect(current).toBe('old');
+    seek.value = '2500';
+    seek.dispatchEvent(new Event('input'));
+    current = container.querySelector('li.current')?.textContent;
+    expect(current).toBe('new');
+    expect(container.querySelectorAll('li').length).toBeGreaterThanOrEqual(1);
+    render();
+  });
+});

--- a/src/client/commitLog.ts
+++ b/src/client/commitLog.ts
@@ -1,0 +1,47 @@
+import type { Commit } from './types.js';
+
+export interface CommitLogOptions {
+  container: HTMLElement;
+  seek: HTMLInputElement;
+  commits: Commit[];
+  visible?: number;
+}
+
+export const createCommitLog = ({
+  container,
+  seek,
+  commits,
+  visible = 20,
+}: CommitLogOptions) => {
+  const list = document.createElement('ul');
+  list.className = 'commit-list';
+  container.appendChild(list);
+
+  const marker = document.createElement('div');
+  marker.className = 'commit-marker';
+  container.appendChild(marker);
+
+  const render = (): void => {
+    const ts = Number(seek.value);
+    let index = commits.findIndex(
+      (c) => c.commit.committer.timestamp * 1000 <= ts,
+    );
+    if (index === -1) index = commits.length - 1;
+    const start = Math.max(0, index - visible + 1);
+    const slice = commits.slice(start, index + 1).reverse();
+    list.innerHTML = '';
+    slice.forEach((c, i) => {
+      const li = document.createElement('li');
+      li.textContent = c.commit.message.split('\n')[0];
+      if (start + (slice.length - 1 - i) === index) {
+        li.classList.add('current');
+      }
+      list.appendChild(li);
+    });
+  };
+
+  seek.addEventListener('input', render);
+  render();
+
+  return { render };
+};

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,7 @@
 import { fetchCommits, fetchLineCounts } from './api.js';
 import { createPlayer } from './player.js';
 import { createFileSimulation } from './lines.js';
+import { createCommitLog } from './commitLog.js';
 
 const json = (input: string) => fetch(input).then((r) => r.json());
 const commits = await fetchCommits(json);
@@ -12,6 +13,7 @@ const seek = document.getElementById('seek') as HTMLInputElement;
 const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
+const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const { update } = createFileSimulation(sim);
 
 const updateLines = async (): Promise<void> => {
@@ -22,4 +24,5 @@ const updateLines = async (): Promise<void> => {
 seek.addEventListener('input', updateLines);
 
 createPlayer({ seek, duration, playButton, start, end });
+createCommitLog({ container: logContainer, seek, commits });
 updateLines();


### PR DESCRIPTION
## Summary
- show a scrolling commit log overlay
- sync commit list with timeline
- highlight the current commit
- test commit log behavior

## Testing
- `npx eslint "**/*.ts" --max-warnings=0`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dcb3de6d4832abdd950bcd4fcc84f