### PR TITLE
Improve commit log timeline visuals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,8 @@
         font-family: monospace;
         color: #fff;
         pointer-events: none;
-        overflow: hidden;
+        overflow: visible;
+        background: rgba(0, 0, 0, 0.5);
         mask-image: linear-gradient(
           to bottom,
           transparent,
@@ -32,7 +33,9 @@
         padding: 0;
         display: flex;
         flex-direction: column;
-        gap: 2px;
+      }
+      #commit-log li {
+        white-space: nowrap;
       }
       #commit-log li.current {
         color: #0ff;

--- a/src/client/commitLog.ts
+++ b/src/client/commitLog.ts
@@ -5,6 +5,7 @@ export interface CommitLogOptions {
   seek: HTMLInputElement;
   commits: Commit[];
   visible?: number;
+  msPerPx?: number;
 }
 
 export const createCommitLog = ({
@@ -12,6 +13,7 @@ export const createCommitLog = ({
   seek,
   commits,
   visible = 20,
+  msPerPx = 1e6,
 }: CommitLogOptions) => {
   const list = document.createElement('ul');
   list.className = 'commit-list';
@@ -33,6 +35,13 @@ export const createCommitLog = ({
     slice.forEach((c, i) => {
       const li = document.createElement('li');
       li.textContent = c.commit.message.split('\n')[0];
+      if (i > 0) {
+        const prev = slice[i - 1];
+        const diff =
+          (c.commit.committer.timestamp - prev.commit.committer.timestamp) *
+          1000;
+        li.style.marginTop = `${diff / msPerPx}px`;
+      }
       if (start + (slice.length - 1 - i) === index) {
         li.classList.add('current');
       }


### PR DESCRIPTION
## Summary
- show commit timeline gaps proportional to time
- prevent text wrapping and allow overflow beyond background
- add translucent background to commit log panel

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dccedb098832a8dc93b35d6fb99e0