### PR TITLE
Add tab visibility pause

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -118,4 +118,31 @@ describe('lines module', () => {
     const scale = computeScale(1000, 200, [{ file: 'a', lines: 1 }]);
     expect(scale).toBe(200);
   });
+
+  it('pauses and resumes the simulation', () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback): number => {
+      callbacks.push(cb);
+      return 1;
+    };
+    const sim = createFileSimulation(div, { raf, now: () => 0 });
+    sim.pause();
+    callbacks[0]?.(0);
+    expect(callbacks).toHaveLength(1);
+    sim.resume();
+    expect(callbacks).toHaveLength(2);
+    sim.destroy();
+  });
 });

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -105,4 +105,33 @@ describe('createPlayer', () => {
 
     expect(listener).toHaveBeenCalled();
   });
+
+  it('pauses and resumes playback', () => {
+    document.body.innerHTML = `
+      <button id="play"></button>
+      <input id="seek" />
+      <input id="duration" />
+    `;
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '1';
+
+    const raf = jest.fn();
+
+    const player = createPlayer({
+      seek,
+      duration,
+      playButton,
+      start: 0,
+      end: 2,
+      raf,
+      now: () => 0,
+    });
+
+    player.resume();
+    expect(playButton.textContent).toBe('Pause');
+    player.pause();
+    expect(playButton.textContent).toBe('Play');
+  });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,7 +14,8 @@ const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
-const { update } = createFileSimulation(sim);
+const simInstance = createFileSimulation(sim);
+const { update } = simInstance;
 
 const updateLines = async (): Promise<void> => {
   const counts = await fetchLineCounts(json, Number(seek.value));
@@ -23,6 +24,18 @@ const updateLines = async (): Promise<void> => {
 
 seek.addEventListener('input', updateLines);
 
-createPlayer({ seek, duration, playButton, start, end });
+const player = createPlayer({ seek, duration, playButton, start, end });
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();
+
+let wasPlaying = false;
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    wasPlaying = player.isPlaying();
+    player.pause();
+    simInstance.pause();
+  } else {
+    simInstance.resume();
+    if (wasPlaying) player.resume();
+  }
+});

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -210,7 +210,9 @@ export const createFileSimulation = (
 
   let frameId = 0;
   let last = now();
+  let running = true;
   const step = (time: number): void => {
+    if (!running) return;
     Engine.update(engine, time - last);
     last = time;
     for (const { body, el, r } of Object.values(bodies)) {
@@ -225,8 +227,21 @@ export const createFileSimulation = (
   };
 
   frameId = raf(step);
-  const destroy = (): void => cancelAnimationFrame(frameId);
-  return { update, destroy };
+  const pause = (): void => {
+    running = false;
+    cancelAnimationFrame(frameId);
+  };
+  const resume = (): void => {
+    if (running) return;
+    running = true;
+    last = now();
+    frameId = raf(step);
+  };
+  const destroy = (): void => {
+    running = false;
+    cancelAnimationFrame(frameId);
+  };
+  return { update, pause, resume, destroy };
 };
 
 export const renderFileSimulation = (

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -41,14 +41,22 @@ export const createPlayer = ({
     }
   };
 
-  const togglePlay = () => {
-    playing = !playing;
+  const setPlaying = (state: boolean) => {
+    playing = state;
     playButton.textContent = playing ? 'Pause' : 'Play';
     if (playing) {
       lastTime = now();
       raf(tick);
     }
   };
+
+  const togglePlay = (): void => {
+    setPlaying(!playing);
+  };
+
+  const pause = (): void => setPlaying(false);
+  const resume = (): void => setPlaying(true);
+  const isPlaying = (): boolean => playing;
 
   playButton.addEventListener('click', togglePlay);
 
@@ -57,5 +65,5 @@ export const createPlayer = ({
   seek.value = String(start);
   seek.dispatchEvent(new Event('input'));
 
-  return { togglePlay };
+  return { togglePlay, pause, resume, isPlaying };
 };


### PR DESCRIPTION
## Summary
- pause/resume playback when tab is hidden
- expose pause/resume helpers in player and file simulation
- test pause and resume logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dcddc3f20832aa68198bfb6c9b9ae