### PR TITLE
Enhance commit timeline visuals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         color: #fff;
         pointer-events: none;
         overflow: visible;
-        background: rgba(0, 0, 0, 0.5);
+        text-shadow: 0 0 2px #000;
         mask-image: linear-gradient(
           to bottom,
           transparent,
@@ -26,6 +26,15 @@
           black calc(100% - 20px),
           transparent
         );
+      }
+      #commit-log::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 8px;
+        width: 2px;
+        background: rgba(255, 255, 255, 0.5);
       }
       #commit-log ul {
         list-style: none;
@@ -36,17 +45,26 @@
       }
       #commit-log li {
         white-space: nowrap;
+        position: relative;
+        padding-left: 16px;
+      }
+      #commit-log li::before {
+        content: '•';
+        position: absolute;
+        left: 8px;
+        transform: translateX(-50%);
       }
       #commit-log li.current {
         color: #0ff;
+        font-weight: bold;
       }
       .commit-marker {
         position: absolute;
-        left: 0;
-        right: 0;
+        left: 8px;
         top: 50%;
-        height: 2px;
-        background: #0ff;
+        transform: translate(-50%, -50%);
+        color: #0f0;
+        font-size: 20px;
       }
       .file-circle {
         display: flex;

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -114,8 +114,8 @@ describe('lines module', () => {
     expect(linear).toBeLessThan(nonlinear);
   });
 
-  it('returns base scale when ratio below threshold', () => {
+  it('returns eased scale when ratio exceeds threshold', () => {
     const scale = computeScale(1000, 200, [{ file: 'a', lines: 1 }]);
-    expect(scale).toBe(200);
+    expect(scale).toBeCloseTo(197.7, 1);
   });
 });

--- a/src/client/commitLog.ts
+++ b/src/client/commitLog.ts
@@ -21,6 +21,7 @@ export const createCommitLog = ({
 
   const marker = document.createElement('div');
   marker.className = 'commit-marker';
+  marker.textContent = '•';
   container.appendChild(marker);
 
   const render = (): void => {

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -43,7 +43,7 @@ export const computeScale = (
     0,
   );
   const ratio = totalArea / (width * height);
-  const threshold = 0.2;
+  const threshold = 0.15;
   if (ratio <= threshold) return base;
   const easing = Math.pow(threshold / ratio, 0.25);
   return base * easing;


### PR DESCRIPTION
## Summary
- tweak circle scaling to give more margin
- restyle commit timeline with vertical guide and bullets
- update unit tests for new scaling logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dcec0ddec832a869ddd20163bb195