### PR TITLE
Add resize handling to simulation

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -145,4 +145,36 @@ describe('lines module', () => {
     expect(callbacks).toHaveLength(2);
     sim.destroy();
   });
+
+  it('resizes the simulation space', () => {
+    const div = document.createElement('div');
+    let size = 200;
+    div.getBoundingClientRect = () => ({
+      width: size,
+      height: size,
+      top: 0,
+      left: 0,
+      bottom: size,
+      right: size,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback): number => {
+      callbacks.push(cb);
+      return 1;
+    };
+    const sim = createFileSimulation(div, { raf, now: () => 0 });
+    const data: LineCount[] = [{ file: 'a', lines: 5 }];
+    sim.update(data);
+    callbacks[0]?.(0);
+    const circle = div.querySelector('.file-circle') as HTMLElement;
+    const initial = circle.style.width;
+    size = 400;
+    sim.resize();
+    callbacks[1]?.(0);
+    expect(circle.style.width).not.toBe(initial);
+    sim.destroy();
+  });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,7 +15,7 @@ const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const simInstance = createFileSimulation(sim);
-const { update } = simInstance;
+const { update, resize } = simInstance;
 
 const updateLines = async (): Promise<void> => {
   const counts = await fetchLineCounts(json, Number(seek.value));
@@ -27,6 +27,7 @@ seek.addEventListener('input', updateLines);
 const player = createPlayer({ seek, duration, playButton, start, end });
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();
+window.addEventListener('resize', resize);
 
 let wasPlaying = false;
 document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- update simulation engine to support dynamic resizing
- hook resize listener in the client
- test resize functionality

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dcf2a3820832a99233af7a56fc6bd