### PR TITLE
Adjust commit log display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,12 +12,13 @@
         left: 0;
         top: 0;
         bottom: 0;
-        width: 250px;
+        width: 100%;
         padding: 10px;
+        box-sizing: border-box;
         font-family: monospace;
         color: #fff;
         pointer-events: none;
-        overflow: visible;
+        overflow: hidden;
         text-shadow: 0 0 4px #000;
         mask-image: linear-gradient(
           to bottom,
@@ -47,9 +48,9 @@
         width: 100%;
       }
       #commit-log li {
-        white-space: nowrap;
         position: relative;
         padding-left: 16px;
+        word-break: break-word;
       }
       #commit-log li::before {
         content: '•';


### PR DESCRIPTION
## Summary
- expand commit log to full width so messages are not cut off
- allow wrapping of commit messages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd1e4e130832ab023a7966b2d77f2