### PR TITLE
Add timestamp overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,17 @@
       body { margin: 0; overflow: hidden; }
       #sim { position: fixed; inset: 0; overflow: hidden; }
       #controls { position: absolute; top: 10px; left: 10px; z-index: 1; }
+      #timestamp {
+        position: fixed;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        font-family: monospace;
+        color: #fff;
+        text-shadow: 0 0 4px #000;
+        pointer-events: none;
+        z-index: 1;
+      }
       #commit-log {
         position: fixed;
         left: 0;
@@ -134,6 +145,7 @@
       <input type="range" id="seek" />
       <input type="number" id="duration" value="20" min="1" />s
     </div>
+    <div id="timestamp"></div>
     <div id="sim"></div>
     <div id="commit-log"></div>
     <script type="importmap">

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,19 +14,29 @@ const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
+const timestampEl = document.getElementById('timestamp') as HTMLDivElement;
 const simInstance = createFileSimulation(sim);
 const { update, resize } = simInstance;
+
+const updateTimestamp = () => {
+  const date = new Date(Number(seek.value));
+  timestampEl.textContent = date.toISOString();
+};
 
 const updateLines = async (): Promise<void> => {
   const counts = await fetchLineCounts(json, Number(seek.value));
   update(counts);
 };
 
-seek.addEventListener('input', updateLines);
+seek.addEventListener('input', () => {
+  updateLines();
+  updateTimestamp();
+});
 
 const player = createPlayer({ seek, duration, playButton, start, end });
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();
+updateTimestamp();
 window.addEventListener('resize', resize);
 
 let wasPlaying = false;


### PR DESCRIPTION
## Summary
- display timestamp on screen
- update timestamp with playback

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd4666f50832a8604ac866e93b5e9