### PR TITLE
Stop simulation when playback ends

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -132,6 +132,43 @@ describe('createPlayer', () => {
     player.resume();
     expect(playButton.textContent).toBe('Pause');
     player.pause();
-    expect(playButton.textContent).toBe('Play');
+  expect(playButton.textContent).toBe('Play');
+  });
+
+  it('notifies play state changes', () => {
+    document.body.innerHTML = `
+      <button id="play"></button>
+      <input id="seek" />
+      <input id="duration" />
+    `;
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '1';
+
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback) => {
+      callbacks.push(cb);
+      return 1;
+    };
+
+    const stateListener = jest.fn();
+
+    const player = createPlayer({
+      seek,
+      duration,
+      playButton,
+      start: 0,
+      end: 2,
+      raf,
+      now: () => 0,
+      onPlayStateChange: stateListener,
+    });
+
+    player.resume();
+    expect(stateListener).toHaveBeenCalledWith(true);
+    callbacks[0]?.(0);
+    callbacks[1]?.(2000);
+    expect(stateListener).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,7 +15,8 @@ const playButton = document.getElementById('play') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const simInstance = createFileSimulation(sim);
-const { update, resize } = simInstance;
+const { update, resize, pause: simPause, resume: simResume } = simInstance;
+simPause();
 
 const updateLines = async (): Promise<void> => {
   const counts = await fetchLineCounts(json, Number(seek.value));
@@ -24,7 +25,17 @@ const updateLines = async (): Promise<void> => {
 
 seek.addEventListener('input', updateLines);
 
-const player = createPlayer({ seek, duration, playButton, start, end });
+const player = createPlayer({
+  seek,
+  duration,
+  playButton,
+  start,
+  end,
+  onPlayStateChange: (playing) => {
+    if (playing) simResume();
+    else simPause();
+  },
+});
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();
 window.addEventListener('resize', resize);

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -6,6 +6,7 @@ export interface PlayerOptions {
   end: number;
   raf?: (cb: FrameRequestCallback) => number;
   now?: () => number;
+  onPlayStateChange?: (playing: boolean) => void;
 }
 
 export const createPlayer = ({
@@ -16,6 +17,7 @@ export const createPlayer = ({
   end,
   raf = requestAnimationFrame,
   now = performance.now.bind(performance),
+  onPlayStateChange,
 }: PlayerOptions) => {
   let playing = false;
   let lastTime = 0;
@@ -36,8 +38,7 @@ export const createPlayer = ({
     if (next < end) {
       raf(tick);
     } else {
-      playing = false;
-      playButton.textContent = 'Play';
+      setPlaying(false);
     }
   };
 
@@ -48,6 +49,7 @@ export const createPlayer = ({
       lastTime = now();
       raf(tick);
     }
+    onPlayStateChange?.(playing);
   };
 
   const togglePlay = (): void => {


### PR DESCRIPTION
## Summary
- notify listeners when playback state changes
- pause/resume physics simulation with the player
- test the new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd484605c832abce6cad5ed1eb3db