### PR TITLE
Remove commit bullet and update marker color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,10 +53,7 @@
         word-break: break-word;
       }
       #commit-log li::before {
-        content: '•';
-        position: absolute;
-        left: 8px;
-        transform: translateX(-50%);
+        display: none;
       }
       #commit-log li.current {
         color: #0ff;
@@ -67,7 +64,7 @@
         left: 8px;
         top: 50%;
         transform: translate(-50%, -50%);
-        color: #0f0;
+        color: #0ff;
         font-size: 20px;
       }
       .file-circle {


### PR DESCRIPTION
## Summary
- remove bullet from commit list items
- match commit marker color with current line

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd48f6d64832ab25d57df0329151f