### PR TITLE
Keep simulation running

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -16,8 +16,7 @@ const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const timestampEl = document.getElementById('timestamp') as HTMLDivElement;
 const simInstance = createFileSimulation(sim);
-const { update, resize, pause: simPause, resume: simResume } = simInstance;
-simPause();
+const { update, resize } = simInstance;
 
 const updateTimestamp = () => {
   const date = new Date(Number(seek.value));
@@ -40,10 +39,6 @@ const player = createPlayer({
   playButton,
   start,
   end,
-  onPlayStateChange: (playing) => {
-    if (playing) simResume();
-    else simPause();
-  },
 });
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();


### PR DESCRIPTION
## Summary
- keep the file simulation running regardless of the timeline playback state

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd5deeedc832a9fed8f5bc9bf97a4