### PR TITLE
Fix removal animation timing

### DIFF
--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -3,6 +3,7 @@ import Matter from 'matter-js';
 const { Bodies, Body, Composite, Engine } = Matter;
 
 const MIN_CIRCLE_SIZE = 1;
+const CHAR_ANIMATION_MS = 1500;
 
 const fileColors: Record<string, string> = {
   '.ts': '#2b7489',
@@ -177,7 +178,10 @@ export const createFileSimulation = (
     Composite.remove(engine.world, info.body);
     delete bodies[name];
     delete displayCounts[name];
-    setTimeout(() => container.removeChild(info.el), 1000);
+    setTimeout(
+      () => container.removeChild(info.el),
+      CHAR_ANIMATION_MS + 100,
+    );
   };
   const createWalls = (w: number, h: number): Matter.Body[] => [
     Bodies.rectangle(w / 2, h + 10, w, 20, { isStatic: true }),


### PR DESCRIPTION
## Summary
- allow removal characters to fully animate

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd5f05364832aa863b69d28167ae8