### PR TITLE
Adjust commit log spacing

### DIFF
--- a/src/client/commitLog.ts
+++ b/src/client/commitLog.ts
@@ -5,15 +5,13 @@ export interface CommitLogOptions {
   seek: HTMLInputElement;
   commits: Commit[];
   visible?: number;
-  msPerPx?: number;
 }
 
 export const createCommitLog = ({
   container,
   seek,
   commits,
-  visible = 20,
-  msPerPx = 1e6,
+  visible = 15,
 }: CommitLogOptions) => {
   const list = document.createElement('ul');
   list.className = 'commit-list';
@@ -38,6 +36,15 @@ export const createCommitLog = ({
     const end = Math.min(commits.length, index + visible + 1);
     const slice = commits.slice(start, end);
     list.innerHTML = '';
+
+    const spanMs =
+      slice.length > 1
+        ?
+            (slice[0].commit.committer.timestamp -
+              slice[slice.length - 1].commit.committer.timestamp) *
+          1000
+        : 1;
+    const msPerPx = spanMs / Math.max(container.clientHeight, 1);
     slice.forEach((c, i) => {
       const li = document.createElement('li');
       li.textContent = c.commit.message.split('\n')[0];


### PR DESCRIPTION
## Summary
- compute commit log spacing based on container height
- reduce default visible entries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd63763ac832ab88e4e394dc7b49c