### PR TITLE
Prevent NaN scale in computeScale

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -119,6 +119,11 @@ describe('lines module', () => {
     expect(scale).toBeCloseTo(197.7, 1);
   });
 
+  it('returns 0 when area is zero', () => {
+    const scale = computeScale(0, 200, [{ file: 'a', lines: 1 }]);
+    expect(scale).toBe(0);
+  });
+
   it('pauses and resumes the simulation', () => {
     const div = document.createElement('div');
     div.getBoundingClientRect = () => ({

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -88,7 +88,7 @@ export const computeScale = (
   );
   const ratio = totalArea / (width * height);
   const threshold = 0.15;
-  if (ratio <= threshold) return base;
+  if (!Number.isFinite(ratio) || ratio <= threshold) return base;
   const easing = Math.pow(threshold / ratio, 0.25);
   return base * easing;
 };


### PR DESCRIPTION
## Summary
- avoid NaN result when width or height is zero in computeScale
- add regression test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd6df0bac832a8d1cdbf54407dbda