### PR TITLE
Improve spawn handling

### DIFF
--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -4,6 +4,7 @@ const { Bodies, Body, Composite, Engine } = Matter;
 
 const MIN_CIRCLE_SIZE = 1;
 const CHAR_ANIMATION_MS = 1500;
+const MAX_SPAWN_PER_UPDATE = 50;
 
 const fileColors: Record<string, string> = {
   '.ts': '#2b7489',
@@ -144,7 +145,13 @@ export const createFileSimulation = (
     remove: number,
   ): void => {
     const { x, y } = info.body.position;
-    for (let i = 0; i < add; i++) {
+    let addLeft = add;
+    let removeLeft = remove;
+    const addSpawn = Math.min(addLeft, MAX_SPAWN_PER_UPDATE);
+    const removeSpawn = Math.min(removeLeft, MAX_SPAWN_PER_UPDATE);
+    addLeft -= addSpawn;
+    removeLeft -= removeSpawn;
+    for (let i = 0; i < addSpawn; i++) {
       const offset = {
         x: Math.random() * width - x,
         y: Math.random() * height - y,
@@ -154,7 +161,7 @@ export const createFileSimulation = (
         info.countEl.textContent = String(displayCounts[file]);
       });
     }
-    for (let i = 0; i < remove; i++) {
+    for (let i = 0; i < removeSpawn; i++) {
       const offset = {
         x: Math.random() * window.innerWidth - (rect.left + x),
         y: Math.random() * window.innerHeight - (rect.top + y),
@@ -163,6 +170,14 @@ export const createFileSimulation = (
         displayCounts[file]--;
         info.countEl.textContent = String(displayCounts[file]);
       });
+    }
+    if (addLeft) {
+      displayCounts[file] += addLeft;
+      info.countEl.textContent = String(displayCounts[file]);
+    }
+    if (removeLeft) {
+      displayCounts[file] -= removeLeft;
+      info.countEl.textContent = String(displayCounts[file]);
     }
   };
 


### PR DESCRIPTION
## Summary
- limit per-update char spawn events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dd852d0f8832a86cf242644864f9a