### PR TITLE
feat(ui): enlarge timestamp and localize

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
         left: 50%;
         transform: translateX(-50%);
         font-family: monospace;
-        font-size: 20px;
+        font-size: 36px;
         color: #fff;
         text-shadow: 0 0 4px #000;
         pointer-events: none;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -20,7 +20,7 @@ const { update, resize } = simInstance;
 
 const updateTimestamp = () => {
   const date = new Date(Number(seek.value));
-  timestampEl.textContent = date.toISOString();
+  timestampEl.textContent = date.toLocaleString();
 };
 
 const updateLines = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- enlarge the timestamp display
- show local timezone in timestamp

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dda373bbc832abf65d5cfb91eded4