### PR TITLE
feat(player): stop function and playback effects

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -141,6 +141,7 @@
   <body>
     <div id="controls">
       <button id="play">Play</button>
+      <button id="stop">Stop</button>
       <input type="range" id="seek" />
       <input type="number" id="duration" value="20" min="1" />s
     </div>

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -182,4 +182,27 @@ describe('lines module', () => {
     expect(circle.style.width).not.toBe(initial);
     sim.destroy();
   });
+
+  it('toggles character effects', () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
+    sim.setEffectsEnabled(false);
+    sim.update([{ file: 'a', lines: 1 }]);
+    expect(div.querySelectorAll('.add-char').length).toBe(0);
+    sim.setEffectsEnabled(true);
+    sim.update([{ file: 'a', lines: 2 }]);
+    expect(div.querySelectorAll('.add-char').length).toBeGreaterThan(0);
+    sim.destroy();
+  });
 });

--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -135,6 +135,61 @@ describe('createPlayer', () => {
   expect(playButton.textContent).toBe('Play');
   });
 
+  it('stops and resets', () => {
+    document.body.innerHTML = `
+      <button id="play"></button>
+      <input id="seek" />
+      <input id="duration" />
+    `;
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '1';
+
+    const player = createPlayer({
+      seek,
+      duration,
+      playButton,
+      start: 0,
+      end: 2,
+      raf: jest.fn(),
+      now: () => 0,
+    });
+
+    seek.value = '1';
+    player.stop();
+    expect(seek.value).toBe('0');
+    expect(playButton.textContent).toBe('Play');
+  });
+
+  it('resets when playing from end', () => {
+    document.body.innerHTML = `
+      <button id="play"></button>
+      <input id="seek" />
+      <input id="duration" />
+    `;
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    const duration = document.getElementById('duration') as HTMLInputElement;
+    duration.value = '1';
+
+    const raf = jest.fn();
+    createPlayer({
+      seek,
+      duration,
+      playButton,
+      start: 0,
+      end: 2,
+      raf,
+      now: () => 0,
+    });
+
+    seek.value = '2';
+    playButton.click();
+    expect(seek.value).toBe('0');
+    expect(playButton.textContent).toBe('Pause');
+  });
+
   it('notifies play state changes', () => {
     document.body.innerHTML = `
       <button id="play"></button>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -12,6 +12,7 @@ const end = commits[0].commit.committer.timestamp * 1000;
 const seek = document.getElementById('seek') as HTMLInputElement;
 const duration = document.getElementById('duration') as HTMLInputElement;
 const playButton = document.getElementById('play') as HTMLButtonElement;
+const stopButton = document.getElementById('stop') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const timestampEl = document.getElementById('timestamp') as HTMLDivElement;
@@ -39,7 +40,9 @@ const player = createPlayer({
   playButton,
   start,
   end,
+  onPlayStateChange: (p) => simInstance.setEffectsEnabled(p),
 });
+stopButton.addEventListener('click', player.stop);
 createCommitLog({ container: logContainer, seek, commits });
 updateLines();
 updateTimestamp();

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -114,6 +114,7 @@ export const createFileSimulation = (
   const prevCounts: Record<string, number> = {};
   const displayCounts: Record<string, number> = {};
   let currentData: LineCount[] = [];
+  let effectsEnabled = false;
 
   const spawnChar = (
     parent: HTMLElement,
@@ -143,6 +144,11 @@ export const createFileSimulation = (
     add: number,
     remove: number,
   ): void => {
+    if (!effectsEnabled) {
+      displayCounts[file] = (displayCounts[file] ?? 0) + add - remove;
+      info.countEl.textContent = String(displayCounts[file]);
+      return;
+    }
     const { x, y } = info.body.position;
     for (let i = 0; i < add; i++) {
       const offset = {
@@ -310,7 +316,10 @@ export const createFileSimulation = (
     running = false;
     cancelAnimationFrame(frameId);
   };
-  return { update, pause, resume, resize, destroy };
+  const setEffectsEnabled = (state: boolean): void => {
+    effectsEnabled = state;
+  };
+  return { update, pause, resume, resize, destroy, setEffectsEnabled };
 };
 
 export const renderFileSimulation = (

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -53,10 +53,19 @@ export const createPlayer = ({
   };
 
   const togglePlay = (): void => {
+    if (!playing && Number(seek.value) >= end) {
+      seek.value = String(start);
+      seek.dispatchEvent(new Event('input'));
+    }
     setPlaying(!playing);
   };
 
   const pause = (): void => setPlaying(false);
+  const stop = (): void => {
+    setPlaying(false);
+    seek.value = String(start);
+    seek.dispatchEvent(new Event('input'));
+  };
   const resume = (): void => setPlaying(true);
   const isPlaying = (): boolean => playing;
 
@@ -67,5 +76,5 @@ export const createPlayer = ({
   seek.value = String(start);
   seek.dispatchEvent(new Event('input'));
 
-  return { togglePlay, pause, resume, isPlaying };
+  return { togglePlay, pause, resume, stop, isPlaying };
 };


### PR DESCRIPTION
## Summary
- add Stop button in the demo
- reset playback when Play is pressed at the end
- show character animations only while playing
- cover new behavior with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de02df49c832a92a04cac7c510e1b