### PR TITLE
Add character effect limit

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -4,6 +4,7 @@ import {
   renderFileSimulation,
   computeScale,
   createFileSimulation,
+  MAX_EFFECT_CHARS,
 } from '../client/lines';
 import type { LineCount } from '../client/types';
 
@@ -203,6 +204,27 @@ describe('lines module', () => {
     sim.setEffectsEnabled(true);
     sim.update([{ file: 'a', lines: 2 }]);
     expect(div.querySelectorAll('.add-char').length).toBeGreaterThan(0);
+    sim.destroy();
+  });
+
+  it('limits active character effects', () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
+    sim.setEffectsEnabled(true);
+    sim.update([{ file: 'a', lines: MAX_EFFECT_CHARS * 2 }]);
+    const chars = div.querySelectorAll('.add-char').length;
+    expect(chars).toBeLessThanOrEqual(MAX_EFFECT_CHARS);
     sim.destroy();
   });
 });

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -4,6 +4,8 @@ const { Bodies, Body, Composite, Engine } = Matter;
 
 const MIN_CIRCLE_SIZE = 1;
 const CHAR_ANIMATION_MS = 1500;
+export const EFFECT_DROP_THRESHOLD = 50;
+export const MAX_EFFECT_CHARS = 100;
 
 const fileColors: Record<string, string> = {
   '.ts': '#2b7489',
@@ -115,6 +117,7 @@ export const createFileSimulation = (
   const displayCounts: Record<string, number> = {};
   let currentData: LineCount[] = [];
   let effectsEnabled = false;
+  let activeCharCount = 0;
 
   const spawnChar = (
     parent: HTMLElement,
@@ -123,6 +126,20 @@ export const createFileSimulation = (
     onEnd: () => void,
     color?: string,
   ): void => {
+    if (activeCharCount >= MAX_EFFECT_CHARS) {
+      onEnd();
+      return;
+    }
+    if (
+      activeCharCount > EFFECT_DROP_THRESHOLD &&
+      Math.random() <
+        (activeCharCount - EFFECT_DROP_THRESHOLD) /
+          (MAX_EFFECT_CHARS - EFFECT_DROP_THRESHOLD)
+    ) {
+      onEnd();
+      return;
+    }
+    activeCharCount++;
     const span = document.createElement('span');
     span.className = cls;
     span.textContent = Math.random().toString(36).charAt(2);
@@ -134,6 +151,7 @@ export const createFileSimulation = (
     parent.appendChild(span);
     span.addEventListener('animationend', () => {
       span.remove();
+      activeCharCount--;
       onEnd();
     });
   };


### PR DESCRIPTION
## Summary
- limit maximum active character effects
- export constants for effect thresholds
- test that effect limit is enforced

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de1c45070832ab492a0748c81f900