### PR TITLE
Add debug logging for final update

### DIFF
--- a/src/client/commitLog.ts
+++ b/src/client/commitLog.ts
@@ -79,6 +79,10 @@ export const createCommitLog = ({
       }
       list.style.transform = `translateY(${offset}px)`;
     }
+
+    if (index === 0) {
+      console.log('[debug] commit log rendered final commit at', ts);
+    }
   };
 
   seek.addEventListener('input', render);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -25,8 +25,12 @@ const updateTimestamp = () => {
 };
 
 const updateLines = async (): Promise<void> => {
-  const counts = await fetchLineCounts(json, Number(seek.value));
+  const ts = Number(seek.value);
+  const counts = await fetchLineCounts(json, ts);
   update(counts);
+  if (ts >= end) {
+    console.log('[debug] physics area updated for final commit at', ts);
+  }
 };
 
 seek.addEventListener('input', () => {

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -48,6 +48,8 @@ export const createPlayer = ({
     if (playing) {
       lastTime = now();
       raf(tick);
+    } else if (Number(seek.value) >= end) {
+      console.log('[debug] seekbar final update processed at', seek.value);
     }
     onPlayStateChange?.(playing);
   };


### PR DESCRIPTION
## Summary
- add debug logging when playback completes
- log when commit log renders the final commit
- log when physics area handles last update

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de888295c832a89b30b2976d2b7ec