### PR TITLE
Add master clock for animation sync

### DIFF
--- a/src/__tests__/clock.test.ts
+++ b/src/__tests__/clock.test.ts
@@ -1,0 +1,18 @@
+/** @jest-environment jsdom */
+import { createMasterClock } from '../client/clock';
+
+jest.useFakeTimers();
+
+describe('createMasterClock', () => {
+  it('invokes callbacks with shared time', () => {
+    const times: number[] = [];
+    const clock = createMasterClock();
+    clock.request((t) => times.push(t));
+    clock.request((t) => times.push(t));
+    // Advance one frame
+    jest.advanceTimersByTime(16);
+    jest.runOnlyPendingTimers();
+    expect(times[0]).toBe(times[1]);
+    clock.stop();
+  });
+});

--- a/src/client/clock.ts
+++ b/src/client/clock.ts
@@ -1,0 +1,48 @@
+export interface MasterClock {
+  request(cb: FrameRequestCallback): number;
+  cancel(id: number): void;
+  now(): number;
+  start(): void;
+  stop(): void;
+}
+
+export const createMasterClock = (): MasterClock => {
+  const callbacks = new Map<number, FrameRequestCallback>();
+  let running = true;
+  let tickId = 0;
+  let nextId = 1;
+  let current = performance.now();
+
+  const step = (time: number): void => {
+    if (!running) return;
+    current = time;
+    callbacks.forEach((cb) => cb(time));
+    tickId = requestAnimationFrame(step);
+  };
+
+  tickId = requestAnimationFrame(step);
+
+  return {
+    request: (cb) => {
+      const id = nextId++;
+      callbacks.set(id, cb);
+      return id;
+    },
+    cancel: (id) => {
+      callbacks.delete(id);
+    },
+    now: () => current,
+    start: () => {
+      if (running) return;
+      running = true;
+      tickId = requestAnimationFrame(step);
+    },
+    stop: () => {
+      if (!running) return;
+      running = false;
+      cancelAnimationFrame(tickId);
+    },
+  };
+};
+
+export const defaultClock = createMasterClock();

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,4 +1,6 @@
 import type { LineCount } from './types.js';
+import type { MasterClock } from './clock';
+import { defaultClock } from './clock';
 import Matter from 'matter-js';
 const { Bodies, Body, Composite, Engine } = Matter;
 
@@ -98,13 +100,15 @@ export const computeScale = (
 export const createFileSimulation = (
   container: HTMLElement,
   opts: {
+    clock?: MasterClock;
     raf?: (cb: FrameRequestCallback) => number;
     now?: () => number;
     linear?: boolean;
   } = {},
 ) => {
-  const raf = opts.raf ?? requestAnimationFrame;
-  const now = opts.now ?? performance.now.bind(performance);
+  const clock = opts.clock ?? defaultClock;
+  const raf = opts.raf ?? clock.request ?? requestAnimationFrame;
+  const now = opts.now ?? clock.now ?? performance.now.bind(performance);
   let rect = container.getBoundingClientRect();
   let width = rect.width;
   let height = rect.height;
@@ -344,6 +348,7 @@ export const renderFileSimulation = (
   container: HTMLElement,
   data: LineCount[],
   opts: {
+    clock?: MasterClock;
     raf?: (cb: FrameRequestCallback) => number;
     now?: () => number;
     linear?: boolean;

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -1,9 +1,13 @@
+import type { MasterClock } from './clock';
+import { defaultClock } from './clock';
+
 export interface PlayerOptions {
   seek: HTMLInputElement;
   duration: HTMLInputElement;
   playButton: HTMLButtonElement;
   start: number;
   end: number;
+  clock?: MasterClock;
   raf?: (cb: FrameRequestCallback) => number;
   now?: () => number;
   onPlayStateChange?: (playing: boolean) => void;
@@ -15,8 +19,9 @@ export const createPlayer = ({
   playButton,
   start,
   end,
-  raf = requestAnimationFrame,
-  now = performance.now.bind(performance),
+  clock = defaultClock,
+  raf = clock?.request ?? requestAnimationFrame,
+  now = clock?.now ?? performance.now.bind(performance),
   onPlayStateChange,
 }: PlayerOptions) => {
   let playing = false;


### PR DESCRIPTION
## Summary
- introduce a `MasterClock` utility for synchronizing animation frames
- hook player and file simulation to the master clock
- test new clock implementation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dee00f188832a8dd2f6efbbd23437