### PR TITLE
fix clock import path

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,9 @@ export default {
       tsconfig: 'tsconfig.json',
     },
   },
-  moduleNameMapper: {},
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   testMatch: ['**/__tests__/**/*.test.ts'],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -1,6 +1,6 @@
 import type { LineCount } from './types.js';
-import type { MasterClock } from './clock';
-import { defaultClock } from './clock';
+import type { MasterClock } from './clock.js';
+import { defaultClock } from './clock.js';
 import Matter from 'matter-js';
 const { Bodies, Body, Composite, Engine } = Matter;
 

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -1,5 +1,5 @@
-import type { MasterClock } from './clock';
-import { defaultClock } from './clock';
+import type { MasterClock } from './clock.js';
+import { defaultClock } from './clock.js';
 
 export interface PlayerOptions {
   seek: HTMLInputElement;


### PR DESCRIPTION
## Summary
- fix MIME type issue by adding `.js` extension for clock imports
- handle `.js` extensions in Jest

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df0d23b7c832aa82ad5f230932cb3