### PR TITLE
sync animation timing with seekbar

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -16,7 +16,9 @@ const stopButton = document.getElementById('stop') as HTMLButtonElement;
 const sim = document.getElementById('sim') as HTMLDivElement;
 const logContainer = document.getElementById('commit-log') as HTMLDivElement;
 const timestampEl = document.getElementById('timestamp') as HTMLDivElement;
-const simInstance = createFileSimulation(sim);
+const simInstance = createFileSimulation(sim, {
+  now: () => Number(seek.value),
+});
 const { update, resize } = simInstance;
 
 const updateTimestamp = () => {

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -308,9 +308,11 @@ export const createFileSimulation = (
   let last = now();
   let running = true;
   const step = (time: number): void => {
+    void time;
     if (!running) return;
-    Engine.update(engine, time - last);
-    last = time;
+    const current = now();
+    Engine.update(engine, current - last);
+    last = current;
     for (const { body, el, r } of Object.values(bodies)) {
       const { x, y } = body.position;
       el.style.transform = `translate3d(${x - r}px, ${y - r}px, 0) rotate(${body.angle}rad)`;


### PR DESCRIPTION
## Summary
- drive `createFileSimulation` timing from the seekbar
- ignore the timestamp passed by `requestAnimationFrame`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df85cad58832a81fc36be44c4105c