### PR TITLE
Fix allocation overflow by skipping large blobs

### DIFF
--- a/src/__tests__/lineCounts.test.ts
+++ b/src/__tests__/lineCounts.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
-import { getLineCounts } from '../lineCounts';
+import { getLineCounts, MAX_BLOB_SIZE } from '../lineCounts';
 
 const author = { name: 'a', email: 'a@example.com' };
 
@@ -30,5 +30,17 @@ describe('getLineCounts', () => {
 
     const counts = await getLineCounts({ dir, ref: 'HEAD' });
     expect(counts.find((c) => c.file === 'b.bin')).toBeUndefined();
+  });
+
+  it('skips blobs larger than MAX_BLOB_SIZE', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    const large = Buffer.alloc(MAX_BLOB_SIZE + 1, 'a');
+    await fs.promises.writeFile(path.join(dir, 'large.txt'), large);
+    await git.add({ fs, dir, filepath: 'large.txt' });
+    await git.commit({ fs, dir, author, message: 'init' });
+
+    const counts = await getLineCounts({ dir, ref: 'HEAD' });
+    expect(counts.find((c) => c.file === 'large.txt')).toBeUndefined();
   });
 });

--- a/src/lineCounts.ts
+++ b/src/lineCounts.ts
@@ -2,6 +2,8 @@ import * as git from 'isomorphic-git';
 import fs from 'fs';
 import { minimatch } from 'minimatch';
 
+export const MAX_BLOB_SIZE = 10 * 1024 * 1024; // 10 MiB
+
 const isBinary = (buf: Buffer): boolean => {
   const len = Math.min(buf.length, 1000);
   for (let i = 0; i < len; i++) {
@@ -30,6 +32,7 @@ export const getLineCounts = async ({
   for (const file of files) {
     if (ignore.some((p) => minimatch(file, p))) continue;
     const { blob } = await git.readBlob({ fs, dir, oid, filepath: file });
+    if (blob.length > MAX_BLOB_SIZE) continue;
     const buffer = Buffer.from(blob);
     if (isBinary(buffer)) continue;
     const content = buffer.toString('utf8').trimEnd();


### PR DESCRIPTION
## Summary
- handle large Git blobs without failing by skipping blobs larger than 10 MiB
- test that large blobs are ignored

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dfb1729f4832a94d75ffb275082aa