### PR TITLE
Adjust glow effects

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -101,19 +101,19 @@
         overflow: visible;
       }
       .glow-new {
-        box-shadow: 0 0 6px 2px rgba(255, 255, 255, 0.8);
+        box-shadow: 0 0 4px 1px rgba(255, 255, 255, 0.5);
         animation: fadeGlow 0.5s forwards;
       }
       .glow-grow {
-        box-shadow: 0 0 6px 2px rgba(0, 255, 0, 0.8);
+        box-shadow: 0 0 4px 1px rgba(0, 255, 0, 0.5);
         animation: fadeGlow 0.5s forwards;
       }
       .glow-shrink {
-        box-shadow: 0 0 6px 2px rgba(255, 0, 0, 0.8);
+        box-shadow: 0 0 4px 1px rgba(255, 0, 0, 0.5);
         animation: fadeGlow 0.5s forwards;
       }
       .glow-disappear {
-        box-shadow: 0 0 6px 2px rgba(255, 0, 0, 0.8);
+        box-shadow: 0 0 4px 1px rgba(255, 0, 0, 0.5);
         animation: fadeOut 0.5s forwards;
       }
       @keyframes fadeGlow {

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -201,9 +201,11 @@ describe('lines module', () => {
     sim.setEffectsEnabled(false);
     sim.update([{ file: 'a', lines: 1 }]);
     expect(div.querySelectorAll('.add-char').length).toBe(0);
+    expect(div.querySelector('.glow-new')).toBeNull();
     sim.setEffectsEnabled(true);
     sim.update([{ file: 'a', lines: 2 }]);
     expect(div.querySelectorAll('.add-char').length).toBeGreaterThan(0);
+    expect(div.querySelector('.glow-grow')).not.toBeNull();
     sim.destroy();
   });
 

--- a/src/client/lines.ts
+++ b/src/client/lines.ts
@@ -120,6 +120,7 @@ export const createFileSimulation = (
   let activeCharCount = 0;
 
   const addGlow = (el: HTMLElement, cls: string, ms = 500): void => {
+    if (!effectsEnabled) return;
     el.classList.add(cls);
     setTimeout(() => el.classList.remove(cls), ms);
   };


### PR DESCRIPTION
## Summary
- respect `setEffectsEnabled` for glow effects
- lower glow effect intensity
- test glow toggle in simulation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e61b14340832abdfee8dec5c9bc3e