### PR TITLE
Fix test warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,8 @@ export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  globals: {
-    'ts-jest': {
-      useESM: true,
-      tsconfig: 'tsconfig.json',
-    },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', useESM: true }],
   },
   moduleNameMapper: {},
   testMatch: ['**/__tests__/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- update ts-jest configuration to remove deprecated `globals` usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e62518c98832a84d894b4bae090ae