### PR TITLE
Update line fetch guard

### DIFF
--- a/src/__tests__/updateLines.test.ts
+++ b/src/__tests__/updateLines.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+import { createUpdateLines } from '../client/updateLines';
+import type { LineCount } from '../client/types';
+
+describe('createUpdateLines', () => {
+  it('ignores stale fetch results', async () => {
+    const seek = document.createElement('input');
+    const update = jest.fn();
+    const json = jest.fn();
+    const counts1: LineCount[] = [{ file: 'a', lines: 1 }];
+    const counts2: LineCount[] = [{ file: 'b', lines: 2 }];
+
+    let resolveFirst: (v: unknown) => void = () => {};
+    let resolveSecond: (v: unknown) => void = () => {};
+    json
+      .mockReturnValueOnce(new Promise((r) => { resolveFirst = r; }))
+      .mockReturnValueOnce(new Promise((r) => { resolveSecond = r; }));
+
+    const fetch = createUpdateLines({ seek, update, json, end: 0 });
+
+    seek.value = '1';
+    const p1 = fetch();
+    seek.value = '2';
+    const p2 = fetch();
+
+    resolveSecond(counts2);
+    await p2;
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(counts2);
+
+    resolveFirst(counts1);
+    await p1;
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,8 @@
-import { fetchCommits, fetchLineCounts } from './api.js';
+import { fetchCommits } from './api.js';
 import { createPlayer } from './player.js';
 import { createFileSimulation } from './lines.js';
 import { createCommitLog } from './commitLog.js';
+import { createUpdateLines } from './updateLines.js';
 
 const json = (input: string) => fetch(input).then((r) => r.json());
 const commits = await fetchCommits(json);
@@ -24,14 +25,7 @@ const updateTimestamp = () => {
   timestampEl.textContent = date.toLocaleString();
 };
 
-const updateLines = async (): Promise<void> => {
-  const ts = Number(seek.value);
-  const counts = await fetchLineCounts(json, ts);
-  update(counts);
-  if (ts >= end) {
-    console.log('[debug] physics area updated for final commit at', ts);
-  }
-};
+export const updateLines = createUpdateLines({ seek, update, json, end });
 
 seek.addEventListener('input', () => {
   updateLines();

--- a/src/client/updateLines.ts
+++ b/src/client/updateLines.ts
@@ -1,0 +1,24 @@
+import { fetchLineCounts } from './api';
+import type { JsonFetcher } from './api';
+import type { LineCount } from './types.js';
+
+export interface UpdateLinesOptions {
+  seek: HTMLInputElement;
+  update: (counts: LineCount[]) => void;
+  json: JsonFetcher;
+  end: number;
+}
+
+export const createUpdateLines = ({ seek, update, json, end }: UpdateLinesOptions) => {
+  let pendingTimestamp: number | null = null;
+  return async (): Promise<void> => {
+    const ts = Number(seek.value);
+    pendingTimestamp = ts;
+    const counts = await fetchLineCounts(json, ts);
+    if (pendingTimestamp !== ts) return;
+    update(counts);
+    if (ts >= end) {
+      console.log('[debug] physics area updated for final commit at', ts);
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- ignore stale async results by capturing timestamp when fetching counts
- extract `createUpdateLines` helper
- cover new guard logic in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e60522da4832a960d606ad86a9c5e