### PR TITLE
Limit glow to element edges

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -101,19 +101,19 @@
         overflow: visible;
       }
       .glow-new {
-        box-shadow: 0 0 4px 1px rgba(255, 255, 255, 0.5);
+        filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.5));
         animation: fadeGlow 0.5s forwards;
       }
       .glow-grow {
-        box-shadow: 0 0 4px 1px rgba(0, 255, 0, 0.5);
+        filter: drop-shadow(0 0 4px rgba(0, 255, 0, 0.5));
         animation: fadeGlow 0.5s forwards;
       }
       .glow-shrink {
-        box-shadow: 0 0 4px 1px rgba(255, 0, 0, 0.5);
+        filter: drop-shadow(0 0 4px rgba(255, 0, 0, 0.5));
         animation: fadeGlow 0.5s forwards;
       }
       .glow-disappear {
-        box-shadow: 0 0 4px 1px rgba(255, 0, 0, 0.5);
+        filter: drop-shadow(0 0 4px rgba(255, 0, 0, 0.5));
         animation: fadeOut 0.5s forwards;
       }
       @keyframes fadeGlow {


### PR DESCRIPTION
## Summary
- restrict glow effects to element edges using `drop-shadow`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e63e943ec832ab8715ba1029822aa