### PR TITLE
Add react/jsx-runtime mapping

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -175,9 +175,10 @@
     <script type="importmap">
       {
         "imports": {
-          "matter-js": "https://cdn.jsdelivr.net/npm/matter-js@0.20.0/+esm",
-          "react": "https://cdn.jsdelivr.net/npm/react@18.2.0/+esm",
-          "react-dom/client": "https://cdn.jsdelivr.net/npm/react-dom@18.2.0/client/+esm"
+        "matter-js": "https://cdn.jsdelivr.net/npm/matter-js@0.20.0/+esm",
+        "react": "https://cdn.jsdelivr.net/npm/react@18.2.0/+esm",
+        "react-dom/client": "https://cdn.jsdelivr.net/npm/react-dom@18.2.0/client/+esm",
+        "react/jsx-runtime": "https://cdn.jsdelivr.net/npm/react@18.2.0/jsx-runtime/+esm"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- map `react/jsx-runtime` to jsdelivr CDN in `public/index.html`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e6c10a114832aa34c84217446864e