### PR TITLE
Add DOM tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,9 @@ export default {
   transform: {
     '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json', useESM: true }],
   },
-  moduleNameMapper: {},
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   testMatch: ['**/__tests__/**/*.test.ts?(x)'],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/src/__tests__/commitLogDom.test.ts
+++ b/src/__tests__/commitLogDom.test.ts
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { createCommitLog } from '../client/commitLog';
+import type { Commit } from '../client/types';
+
+describe('createCommitLog', () => {
+  it('renders and updates commit list', () => {
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientHeight', { value: 100, configurable: true });
+    const seek = document.createElement('input');
+    const commits: Commit[] = [
+      { commit: { message: 'new', committer: { timestamp: 2 } } },
+      { commit: { message: 'old', committer: { timestamp: 1 } } },
+    ];
+    seek.value = '1500';
+    createCommitLog({ container, seek, commits, visible: 2 });
+
+    expect(container.querySelector('li.current')?.textContent).toBe('old');
+    seek.value = '2500';
+    seek.dispatchEvent(new Event('input'));
+    expect(container.querySelector('li.current')?.textContent).toBe('new');
+    expect(container.querySelector('.commit-marker')).not.toBeNull();
+    expect(container.querySelectorAll('li').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+
+describe('index.tsx', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it('mounts the app', async () => {
+    const createRoot = jest.fn(() => ({ render: jest.fn() }));
+    jest.doMock('react-dom/client', () => ({ createRoot }));
+    await import('../client/index');
+    expect(createRoot).toHaveBeenCalled();
+  });
+});

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -6,7 +6,7 @@ import { createFileSimulation } from './lines.js';
 import { CommitLog } from './components/CommitLog.js';
 import type { Commit } from './types.js';
 
-function App(): React.JSX.Element {
+export function App(): React.JSX.Element {
   const [commits, setCommits] = useState<Commit[]>([]);
   const [seekEl, setSeekEl] = useState<HTMLInputElement | null>(null);
 


### PR DESCRIPTION
## Summary
- add DOM test for `createCommitLog`
- test that the entrypoint mounts the app
- export `App` component for easier testing
- map `.js` to TS modules for Jest

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e6e70ba18832ab99395c7d70f08df