### PR TITLE
Add React-based playback controls

### DIFF
--- a/src/client/components/DurationInput.tsx
+++ b/src/client/components/DurationInput.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface DurationInputProps {
+  defaultValue?: number;
+  onInput?: (value: number) => void;
+}
+
+export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputProps>(
+  ({ defaultValue = 20, onInput }, ref) => (
+    <input
+      type="number"
+      ref={ref}
+      defaultValue={defaultValue}
+      min={1}
+      onInput={
+        onInput ? (e) => onInput(Number((e.target as HTMLInputElement).value)) : undefined
+      }
+    />
+  ),
+);

--- a/src/client/components/PlayButton.tsx
+++ b/src/client/components/PlayButton.tsx
@@ -1,0 +1,47 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { createPlayer } from '../player.js';
+
+export interface PlayButtonHandle {
+  stop: () => void;
+  pause: () => void;
+  resume: () => void;
+  isPlaying: () => boolean;
+}
+
+export interface PlayButtonProps {
+  seekRef: React.RefObject<HTMLInputElement | null>;
+  durationRef: React.RefObject<HTMLInputElement | null>;
+  start: number;
+  end: number;
+  onPlayStateChange: (playing: boolean) => void;
+}
+
+export const PlayButton = forwardRef<PlayButtonHandle, PlayButtonProps>(
+  ({ seekRef, durationRef, start, end, onPlayStateChange }, ref) => {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const playerRef = useRef<ReturnType<typeof createPlayer> | null>(null);
+
+    useEffect(() => {
+      if (!seekRef.current || !durationRef.current || !buttonRef.current) return;
+      const player = createPlayer({
+        seek: seekRef.current,
+        duration: durationRef.current,
+        playButton: buttonRef.current,
+        start,
+        end,
+        onPlayStateChange,
+      });
+      playerRef.current = player;
+      return () => player.pause();
+    }, [seekRef, durationRef, start, end, onPlayStateChange]);
+
+    useImperativeHandle(ref, () => ({
+      stop: () => playerRef.current?.stop(),
+      pause: () => playerRef.current?.pause(),
+      resume: () => playerRef.current?.resume(),
+      isPlaying: () => playerRef.current?.isPlaying() ?? false,
+    }));
+
+    return <button ref={buttonRef}>Play</button>;
+  },
+);

--- a/src/client/components/SeekBar.tsx
+++ b/src/client/components/SeekBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export interface SeekBarProps {
+  onInput: (value: number) => void;
+}
+
+export const SeekBar = React.forwardRef<HTMLInputElement, SeekBarProps>(
+  ({ onInput }, ref) => (
+    <input
+      type="range"
+      ref={ref}
+      onInput={(e) => onInput(Number((e.target as HTMLInputElement).value))}
+    />
+  ),
+);

--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,0 +1,53 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { createFileSimulation } from '../lines.js';
+import { fetchLineCounts } from '../api.js';
+import type { JsonFetcher } from '../api.js';
+
+export interface SimulationAreaHandle {
+  pause: () => void;
+  resume: () => void;
+  setEffectsEnabled: (state: boolean) => void;
+}
+
+interface SimulationAreaProps {
+  timestamp: number;
+  end: number;
+  json: JsonFetcher;
+}
+
+export const SimulationArea = forwardRef<SimulationAreaHandle, SimulationAreaProps>(
+  ({ timestamp, end, json }, ref) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const simRef = useRef<ReturnType<typeof createFileSimulation> | null>(null);
+
+    useEffect(() => {
+      if (!containerRef.current) return;
+      const sim = createFileSimulation(containerRef.current);
+      simRef.current = sim;
+      window.addEventListener('resize', sim.resize);
+      return () => {
+        window.removeEventListener('resize', sim.resize);
+        sim.destroy();
+      };
+    }, []);
+
+    useEffect(() => {
+      if (!simRef.current) return;
+      (async () => {
+        const counts = await fetchLineCounts(json, timestamp);
+        simRef.current?.update(counts);
+        if (timestamp >= end) {
+          console.log('[debug] physics area updated for final commit at', timestamp);
+        }
+      })();
+    }, [timestamp, json, end]);
+
+    useImperativeHandle(ref, () => ({
+      pause: () => simRef.current?.pause(),
+      resume: () => simRef.current?.resume(),
+      setEffectsEnabled: (state: boolean) => simRef.current?.setEffectsEnabled(state),
+    }));
+
+    return <div id="sim" ref={containerRef} />;
+  },
+);

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,84 +1,85 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
-import { fetchCommits, fetchLineCounts } from './api.js';
-import { createPlayer } from './player.js';
-import { createFileSimulation } from './lines.js';
+import { fetchCommits } from './api.js';
 import { CommitLog } from './components/CommitLog.js';
+import { DurationInput } from './components/DurationInput.js';
+import { PlayButton } from './components/PlayButton.js';
+import type { PlayButtonHandle } from './components/PlayButton.js';
+import { SeekBar } from './components/SeekBar.js';
+import { SimulationArea } from './components/SimulationArea.js';
+import type { SimulationAreaHandle } from './components/SimulationArea.js';
 import type { Commit } from './types.js';
 
 function App(): React.JSX.Element {
   const [commits, setCommits] = useState<Commit[]>([]);
-  const [seekEl, setSeekEl] = useState<HTMLInputElement | null>(null);
+  const [start, setStart] = useState(0);
+  const [end, setEnd] = useState(0);
+  const [timestamp, setTimestamp] = useState(0);
+  const [ready, setReady] = useState(false);
+
+  const seekRef = useRef<HTMLInputElement>(null);
+  const durationRef = useRef<HTMLInputElement>(null);
+  const playerRef = useRef<PlayButtonHandle>(null);
+  const simRef = useRef<SimulationAreaHandle>(null);
+  const wasPlaying = useRef(false);
+
+  const json = (input: string) => fetch(input).then((r) => r.json());
 
   useEffect(() => {
-    const json = (input: string) => fetch(input).then((r) => r.json());
     (async () => {
       const commitData = await fetchCommits(json);
       setCommits(commitData);
-
-      const start =
-        commitData[commitData.length - 1].commit.committer.timestamp * 1000;
-      const end = commitData[0].commit.committer.timestamp * 1000;
-
-      const duration = document.getElementById('duration') as HTMLInputElement;
-      const playButton = document.getElementById('play') as HTMLButtonElement;
-      const stopButton = document.getElementById('stop') as HTMLButtonElement;
-      const sim = document.getElementById('sim') as HTMLDivElement;
-      const seekInput = document.getElementById('seek') as HTMLInputElement;
-      setSeekEl(seekInput);
-      const timestampEl = document.getElementById('timestamp') as HTMLDivElement;
-      const simInstance = createFileSimulation(sim);
-      const { update, resize } = simInstance;
-
-      const updateTimestamp = () => {
-        const date = new Date(Number(seekInput.value));
-        timestampEl.textContent = date.toLocaleString();
-      };
-
-      const updateLines = async (): Promise<void> => {
-        const ts = Number(seekInput.value);
-        const counts = await fetchLineCounts(json, ts);
-        update(counts);
-        if (ts >= end) {
-          console.log('[debug] physics area updated for final commit at', ts);
-        }
-      };
-
-      seekInput.addEventListener('input', () => {
-        updateLines();
-        updateTimestamp();
-      });
-
-      const player = createPlayer({
-        seek: seekInput,
-        duration,
-        playButton,
-        start,
-        end,
-        onPlayStateChange: (p) => simInstance.setEffectsEnabled(p),
-      });
-      stopButton.addEventListener('click', player.stop);
-      updateLines();
-      updateTimestamp();
-      window.addEventListener('resize', resize);
-
-      let wasPlaying = false;
-      document.addEventListener('visibilitychange', () => {
-        if (document.hidden) {
-          wasPlaying = player.isPlaying();
-          player.pause();
-          simInstance.pause();
-        } else {
-          simInstance.resume();
-          if (wasPlaying) player.resume();
-        }
-      });
+      const s = commitData[commitData.length - 1].commit.committer.timestamp * 1000;
+      const e = commitData[0].commit.committer.timestamp * 1000;
+      setStart(s);
+      setEnd(e);
+      setTimestamp(s);
+      setReady(true);
     })();
   }, []);
 
-  return <>{commits.length > 0 && seekEl && <CommitLog commits={commits} seek={seekEl} />}</>;
+  useEffect(() => {
+    if (!ready) return;
+    const onVisibility = () => {
+      if (document.hidden) {
+        wasPlaying.current = playerRef.current?.isPlaying() ?? false;
+        playerRef.current?.pause();
+        simRef.current?.pause();
+      } else {
+        simRef.current?.resume();
+        if (wasPlaying.current) playerRef.current?.resume();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [ready]);
+
+  return (
+    <>
+      {ready && (
+        <div id="controls">
+          <PlayButton
+            ref={playerRef}
+            seekRef={seekRef}
+            durationRef={durationRef}
+            start={start}
+            end={end}
+            onPlayStateChange={(p) => simRef.current?.setEffectsEnabled(p)}
+          />
+          <button onClick={() => playerRef.current?.stop()}>Stop</button>
+          <SeekBar ref={seekRef} onInput={setTimestamp} />
+          <DurationInput ref={durationRef} />s
+        </div>
+      )}
+      <div id="timestamp">{new Date(timestamp).toLocaleString()}</div>
+      {ready && (
+        <>
+          <SimulationArea ref={simRef} json={json} timestamp={timestamp} end={end} />
+          {seekRef.current && <CommitLog commits={commits} seek={seekRef.current} />}
+        </>
+      )}
+    </>
+  );
 }
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <App />,
-);
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<App />);


### PR DESCRIPTION
## Summary
- create PlayButton, SeekBar, DurationInput and SimulationArea components
- wire up player and simulation logic via React refs
- rewrite App to use the new components

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npx playwright install chromium`
- `npx playwright test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684e6f15480c832a8c92bafb2aee08e7