### PR TITLE
codex/headless-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ node_modules/
 /dist
 public/**/*.js
 coverage/
+test-results/
+playwright-report/
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ npm install --no-save playwright
 npx playwright install chromium
 npx playwright test
 ```
+Playwright tests live in the `playwright` directory.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './playwright',
+  use: { headless: true },
+});

--- a/playwright/ui.spec.ts
+++ b/playwright/ui.spec.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as git from 'isomorphic-git';
+import type { AddressInfo } from 'net';
+import { test, expect } from '@playwright/test';
+import { createApp } from '../src/app.js';
+
+const author = { name: 'a', email: 'a@example.com' };
+
+test('loads page with play button', async ({ page }) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+  await git.init({ fs, dir });
+  await fs.promises.writeFile(path.join(dir, 'a.txt'), '1\n2\n');
+  await git.add({ fs, dir, filepath: 'a.txt' });
+  await git.commit({ fs, dir, author, message: 'init' });
+
+  const app = await createApp({ repo: dir, branch: 'HEAD' });
+  const server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+
+  await page.goto(`http://localhost:${port}`);
+  await expect(page.locator('text=Play')).toBeVisible();
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add Playwright config and UI test
- ignore Playwright artifacts
- note Playwright test location in README

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_684e727e578c832ab9e8b01c014c3d41