### PR TITLE
Add React hooks for simulation and player

### DIFF
--- a/src/client/components/PlayButton.tsx
+++ b/src/client/components/PlayButton.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
-import { createPlayer } from '../player.js';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { usePlayer } from '../hooks/index.js';
 
 export interface PlayButtonHandle {
   stop: () => void;
@@ -19,28 +19,15 @@ export interface PlayButtonProps {
 export const PlayButton = forwardRef<PlayButtonHandle, PlayButtonProps>(
   ({ seekRef, durationRef, start, end, onPlayStateChange }, ref) => {
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const playerRef = useRef<ReturnType<typeof createPlayer> | null>(null);
+    const { stop, pause, resume, isPlaying } = usePlayer(buttonRef, {
+      seekRef: seekRef as React.RefObject<HTMLInputElement>,
+      durationRef: durationRef as React.RefObject<HTMLInputElement>,
+      start,
+      end,
+      onPlayStateChange,
+    });
 
-    useEffect(() => {
-      if (!seekRef.current || !durationRef.current || !buttonRef.current) return;
-      const player = createPlayer({
-        seek: seekRef.current,
-        duration: durationRef.current,
-        playButton: buttonRef.current,
-        start,
-        end,
-        onPlayStateChange,
-      });
-      playerRef.current = player;
-      return () => player.pause();
-    }, [seekRef, durationRef, start, end, onPlayStateChange]);
-
-    useImperativeHandle(ref, () => ({
-      stop: () => playerRef.current?.stop(),
-      pause: () => playerRef.current?.pause(),
-      resume: () => playerRef.current?.resume(),
-      isPlaying: () => playerRef.current?.isPlaying() ?? false,
-    }));
+    useImperativeHandle(ref, () => ({ stop, pause, resume, isPlaying }));
 
     return <button ref={buttonRef}>Play</button>;
   },

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { createFileSimulation } from '../lines.js';
+import { createPlayer } from '../player.js';
+import type { LineCount } from '../types.js';
+import type { PlayerOptions } from '../player.js';
+
+export const useFileSimulation = (
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  opts: {
+    raf?: (cb: FrameRequestCallback) => number;
+    now?: () => number;
+    linear?: boolean;
+  } = {},
+) => {
+  const simRef = useRef<ReturnType<typeof createFileSimulation> | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const sim = createFileSimulation(containerRef.current, opts);
+    simRef.current = sim;
+    window.addEventListener('resize', sim.resize);
+    return () => {
+      window.removeEventListener('resize', sim.resize);
+      sim.destroy();
+    };
+  }, [containerRef, opts]);
+
+  const update = useCallback((data: LineCount[]) => {
+    simRef.current?.update(data);
+  }, []);
+  const pause = useCallback(() => simRef.current?.pause(), []);
+  const resume = useCallback(() => simRef.current?.resume(), []);
+  const setEffectsEnabled = useCallback(
+    (state: boolean) => simRef.current?.setEffectsEnabled(state),
+    [],
+  );
+
+  return { update, pause, resume, setEffectsEnabled };
+};
+
+export const usePlayer = (
+  buttonRef: React.RefObject<HTMLButtonElement | null>,
+  options: Omit<PlayerOptions, 'playButton' | 'seek' | 'duration'> & {
+    seekRef: React.RefObject<HTMLInputElement | null>;
+    durationRef: React.RefObject<HTMLInputElement | null>;
+  },
+) => {
+  const { seekRef, durationRef, ...opts } = options;
+  const playerRef = useRef<ReturnType<typeof createPlayer> | null>(null);
+
+  useEffect(() => {
+    if (!buttonRef.current || !seekRef.current || !durationRef.current) return;
+    const player = createPlayer({
+      seek: seekRef.current,
+      duration: durationRef.current,
+      playButton: buttonRef.current,
+      ...opts,
+    });
+    playerRef.current = player;
+    return () => player.pause();
+  }, [buttonRef, seekRef, durationRef, opts]);
+
+  const stop = useCallback(() => playerRef.current?.stop(), []);
+  const pause = useCallback(() => playerRef.current?.pause(), []);
+  const resume = useCallback(() => playerRef.current?.resume(), []);
+  const isPlaying = useCallback(
+    () => playerRef.current?.isPlaying() ?? false,
+    [],
+  );
+
+  return { stop, pause, resume, isPlaying };
+};


### PR DESCRIPTION
## Summary
- convert file simulation logic into `useFileSimulation` hook
- convert player logic into `usePlayer` hook
- refactor `SimulationArea` and `PlayButton` to use hooks

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e7af00c9c832a8564a33a45f97830