### PR TITLE
Reactify physics area rendering

### DIFF
--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,7 +1,6 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
-import { useFileSimulation } from '../hooks';
-import { fetchLineCounts } from '../api';
-import type { JsonFetcher } from '../api';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import { useAnimatedSimulation } from '../hooks';
+import type { LineCount } from '../types';
 
 export interface SimulationAreaHandle {
   pause: () => void;
@@ -10,25 +9,13 @@ export interface SimulationAreaHandle {
 }
 
 interface SimulationAreaProps {
-  timestamp: number;
-  end: number;
-  json: JsonFetcher;
+  data: LineCount[];
 }
 
 export const SimulationArea = forwardRef<SimulationAreaHandle, SimulationAreaProps>(
-  ({ timestamp, end, json }, ref) => {
+  ({ data }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const { update, pause, resume, setEffectsEnabled } = useFileSimulation(containerRef);
-
-    useEffect(() => {
-      (async () => {
-        const counts = await fetchLineCounts(json, timestamp);
-        update(counts);
-        if (timestamp >= end) {
-          console.log('[debug] physics area updated for final commit at', timestamp);
-        }
-      })();
-    }, [timestamp, json, end, update]);
+    const { pause, resume, setEffectsEnabled } = useAnimatedSimulation(containerRef, data);
 
     useImperativeHandle(ref, () => ({
       pause,

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -38,6 +38,27 @@ export const useFileSimulation = (
   return { update, pause, resume, setEffectsEnabled };
 };
 
+export const useAnimatedSimulation = (
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  data: LineCount[],
+  opts: {
+    raf?: (cb: FrameRequestCallback) => number;
+    now?: () => number;
+    linear?: boolean;
+  } = {},
+) => {
+  const { update, pause, resume, setEffectsEnabled } = useFileSimulation(
+    containerRef,
+    opts,
+  );
+
+  useEffect(() => {
+    if (data.length) update(data);
+  }, [data, update]);
+
+  return { pause, resume, setEffectsEnabled };
+};
+
 export const usePlayer = (
   buttonRef: React.RefObject<HTMLButtonElement | null>,
   options: Omit<PlayerOptions, 'playButton' | 'seek' | 'duration'> & {


### PR DESCRIPTION
## Summary
- render physics area declaratively
- expose a new `useAnimatedSimulation` hook
- update `App` to fetch line counts and pass them as props

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e80ac5380832ab47e90fefb2862e8