### PR TITLE
unify vite dev and express api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm test
 npm run build            # client build with Vite
 npm start                # defaults to current directory
 # npm start -- --repo path/to/repo
-# npm run dev            # Vite dev server
+# npm run dev            # start Vite dev server with API
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) in your browser.

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,9 +8,10 @@ export interface CreateAppOptions {
   repo: string;
   branch?: string;
   ignore?: string[];
+  serveStatic?: boolean;
 }
 
-export const createApp = async ({ repo, branch: inputBranch, ignore = [] }: CreateAppOptions) => {
+export const createApp = async ({ repo, branch: inputBranch, ignore = [], serveStatic = true }: CreateAppOptions) => {
   const repoDir = path.resolve(repo);
   if (!fs.existsSync(path.join(repoDir, '.git'))) {
     throw new Error(`${repoDir} is not a git repository.`);
@@ -30,7 +31,9 @@ export const createApp = async ({ repo, branch: inputBranch, ignore = [] }: Crea
 
   const app = express();
 
-  app.use(express.static('dist'));
+  if (serveStatic) {
+    app.use(express.static('dist'));
+  }
 
   app.get('/api/commits', (_, res) => {
     res.json(commits);

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,0 +1,12 @@
+import type { Plugin } from 'vite';
+import { createApp } from './app';
+
+export default function viteExpress(): Plugin {
+  return {
+    name: 'vite-express',
+    async configureServer(server) {
+      const app = await createApp({ repo: process.cwd(), serveStatic: false });
+      server.middlewares.use(app);
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import viteExpress from './src/viteExpress';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), viteExpress()],
+  server: {
+    port: 3000,
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- start the Express API in a Vite plugin
- run Vite for development instead of a custom server
- document the new dev server command

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e810f591c832aa4b5ab14a3abbb8f