### PR TITLE
feat(simulation): 🔴 refactor circle DOM to React

### DIFF
--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export interface FileCircleContentProps {
+  path: string;
+  name: string;
+  count: number;
+  countRef: React.Ref<HTMLDivElement>;
+  charsRef: React.Ref<HTMLDivElement>;
+}
+
+export const FileCircleContent = ({
+  path,
+  name,
+  count,
+  countRef,
+  charsRef,
+}: FileCircleContentProps): React.JSX.Element => (
+  <>
+    <div className="path">{path}</div>
+    <div className="name">{name}</div>
+    <div className="count" ref={countRef}>
+      {count}
+    </div>
+    <div className="chars" ref={charsRef} />
+  </>
+);


### PR DESCRIPTION
## Summary
- implement `FileCircleContent` React component
- refactor physics `createFileSimulation` to render circle contents via React

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e821d2ce0832a94dabd4512e6f70b