### PR TITLE
feat(simulation): recycle manage bodies in component

### DIFF
--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,5 +1,10 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { useAnimatedSimulation } from '../hooks';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { createFileSimulation } from '../lines';
 import type { LineCount } from '../types';
 
 export interface SimulationAreaHandle {
@@ -15,13 +20,29 @@ interface SimulationAreaProps {
 export const SimulationArea = forwardRef<SimulationAreaHandle, SimulationAreaProps>(
   ({ data }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null);
-    const { pause, resume, setEffectsEnabled } = useAnimatedSimulation(containerRef, data);
+    const simRef = useRef<ReturnType<typeof createFileSimulation> | null>(null);
 
-    useImperativeHandle(ref, () => ({
-      pause,
-      resume,
-      setEffectsEnabled,
-    }));
+    useEffect(() => {
+      if (!containerRef.current) return;
+      const sim = createFileSimulation(containerRef.current);
+      simRef.current = sim;
+      window.addEventListener('resize', sim.resize);
+      return () => {
+        window.removeEventListener('resize', sim.resize);
+        sim.destroy();
+      };
+    }, []);
+
+    useEffect(() => {
+      if (data.length) simRef.current?.update(data);
+    }, [data]);
+
+    const pause = (): void => simRef.current?.pause();
+    const resume = (): void => simRef.current?.resume();
+    const setEffectsEnabled = (state: boolean): void =>
+      simRef.current?.setEffectsEnabled(state);
+
+    useImperativeHandle(ref, () => ({ pause, resume, setEffectsEnabled }));
 
     return <div id="sim" ref={containerRef} />;
   },


### PR DESCRIPTION
## Summary
- handle Matter.js body lifecycle directly in `SimulationArea`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e84316210832aa272cccaef3f862c