### PR TITLE
Add npm audit and deprecation checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,6 @@
 - Avoid excluding code from coverage unless there is a compelling reason.
   If coverage goals become difficult to meet, document TODO tasks and
   temporarily lower the coverage threshold until those tasks are resolved.
+- Run `npm audit` and address reported vulnerabilities.
+- Investigate any `deprecated` warnings from package installs.
+- Make these checks part of the regular workflow and account for them when updating CI.


### PR DESCRIPTION
## Summary
- document npm audit usage and warnings on deprecated packages in `AGENTS.md`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e876ebe34832ab67e565399f25bd0