### PR TITLE
Increase jest coverage threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 
 - Always run `npm run lint`, `npm test`, and `npm run build` before committing changes.
 - The GitHub Actions workflow runs these commands. Update it when scripts change.
-- TODO: Increase Jest coverage to at least 80%. Add tests for
-  `src/client/index.tsx`.
+* Jest coverage threshold set to 80%.
+  Tests cover `src/client/index.tsx`.
 - Avoid excluding code from coverage unless there is a compelling reason.
   If coverage goals become difficult to meet, document TODO tasks and
   temporarily lower the coverage threshold until those tasks are resolved.

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 60,
+      lines: 80,
     },
   },
 };


### PR DESCRIPTION
## Summary
- bump global `coverageThreshold.lines` to 80
- clarify completed coverage tasks in `AGENTS.md`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e876f53d0832ab136cec06f41d7aa