### PR TITLE
codex/add-index-client-test

### DIFF
--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { App } from '../client/App';
+
+describe('client index', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      if (typeof input === 'string' && input.startsWith('/api/commits')) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve([
+              { commit: { message: 'msg', committer: { timestamp: 1 } } },
+            ]),
+        });
+      }
+      if (typeof input === 'string' && input.startsWith('/api/lines')) {
+        return Promise.resolve({ json: () => Promise.resolve([]) });
+      }
+      return Promise.reject(new Error(`Unexpected url: ${input}`));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('mounts App without crashing', async () => {
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.firstChild).toBeTruthy());
+  });
+});


### PR DESCRIPTION
## Summary
- add an App mounting test to ensure the client index renders without crashing

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e87719218832a8f036b51d9e8d92b