### PR TITLE
Improve React state management

### DIFF
--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,26 +1,52 @@
-import React from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+export interface FileCircleContentHandle {
+  charsEl: HTMLDivElement | null;
+  setCount: (n: number) => void;
+  showGlow: (cls: string, ms?: number) => void;
+}
 
 export interface FileCircleContentProps {
   path: string;
   name: string;
   count: number;
-  countRef: React.Ref<HTMLDivElement>;
-  charsRef: React.Ref<HTMLDivElement>;
+  container: React.RefObject<HTMLDivElement>;
 }
 
-export const FileCircleContent = ({
-  path,
-  name,
-  count,
-  countRef,
-  charsRef,
-}: FileCircleContentProps): React.JSX.Element => (
-  <>
-    <div className="path">{path}</div>
-    <div className="name">{name}</div>
-    <div className="count" ref={countRef}>
-      {count}
-    </div>
-    <div className="chars" ref={charsRef} />
-  </>
-);
+export const FileCircleContent = forwardRef<
+  FileCircleContentHandle,
+  FileCircleContentProps
+>(({ path, name, count, container }, ref) => {
+  const [currentCount, setCurrentCount] = useState(count);
+  const charsRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      charsEl: charsRef.current,
+      setCount: setCurrentCount,
+      showGlow: (cls: string, ms = 500) => {
+        const el = container.current;
+        if (!el) return;
+        el.classList.add(cls);
+        setTimeout(() => el.classList.remove(cls), ms);
+      },
+    }),
+    [container],
+  );
+
+  return (
+    <>
+      <div className="path">{path}</div>
+      <div className="name">{name}</div>
+      <div className="count">{currentCount}</div>
+      <div className="chars" ref={charsRef} />
+    </>
+  );
+});
+


### PR DESCRIPTION
## Summary
- use imperative ref for FileCircleContent to manage glow and count
- track commit log position in state and emit `end` event
- connect glow effects to state flag

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e874b0aa0832a97b2cf0878a3c8da