### PR TITLE
Remove repo option and simplify middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ npm run lint
 npm test
 npm run build            # client build with Vite
 npm start                # defaults to current directory
-# npm start -- --repo path/to/repo
 # npm run dev            # start Vite dev server with API
 ```
 

--- a/playwright/ui.spec.ts
+++ b/playwright/ui.spec.ts
@@ -4,7 +4,8 @@ import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import { test, expect } from '@playwright/test';
-import { createApp } from '../src/app';
+import express from 'express';
+import { createApiMiddleware } from '../src/apiMiddleware';
 
 const author = { name: 'a', email: 'a@example.com' };
 
@@ -15,7 +16,9 @@ test('serves index page', async ({ page }) => {
   await git.add({ fs, dir, filepath: 'a.txt' });
   await git.commit({ fs, dir, author, message: 'init' });
 
-  const app = await createApp({ repo: dir, branch: 'HEAD' });
+  const app = express();
+  app.use(express.static('dist'));
+  app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
   const server = app.listen(0);
   const { port } = server.address() as AddressInfo;
 

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -3,7 +3,8 @@ import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
-import { createApp } from '../app';
+import express from 'express';
+import { createApiMiddleware } from '../apiMiddleware';
 import { fetchCommits, fetchLineCounts, JsonFetcher } from '../client/api';
 
 const author = { name: 'a', email: 'a@example.com' };
@@ -20,7 +21,8 @@ describe('server e2e', () => {
     await git.add({ fs, dir, filepath: 'a.txt' });
     await git.commit({ fs, dir, author, message: 'init' });
 
-    const app = await createApp({ repo: dir, branch: 'HEAD' });
+    const app = express();
+    app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
     const server = app.listen(0);
     const { port } = server.address() as AddressInfo;
 

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,12 +1,11 @@
 import type { Plugin } from 'vite';
-import { createApp } from './app';
+import { createApiMiddleware } from './apiMiddleware';
 
 export default function viteExpress(): Plugin {
   return {
     name: 'vite-express',
     async configureServer(server) {
-      const app = await createApp({ repo: process.cwd(), serveStatic: false });
-      server.middlewares.use(app);
+      server.middlewares.use(await createApiMiddleware());
     },
   };
 }


### PR DESCRIPTION
## Summary
- default middleware repo to process.cwd
- remove `--repo` flag from the CLI
- update vite plugin and docs

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e841b1c04832a8f837149774231f7