### PR TITLE
feat(server): :sparkles: dynamic repo handling

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -4,7 +4,8 @@ import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import express from 'express';
-import { createApiMiddleware } from '../apiMiddleware';
+import { createApiMiddleware, createApiMiddlewareFromApp } from '../apiMiddleware';
+import { appSettings } from '../appSettings';
 import { fetchCommits, fetchLineCounts, JsonFetcher } from '../client/api';
 
 const author = { name: 'a', email: 'a@example.com' };
@@ -32,6 +33,35 @@ describe('server e2e', () => {
 
     expect(commits[0].commit.message).toBe('init\n');
     expect(counts[0]?.file).toBe('a.txt');
+
+    server.close();
+  });
+
+  it('responds to branch changes via app settings', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+    await git.add({ fs, dir, filepath: 'a.txt' });
+    await git.commit({ fs, dir, author, message: 'init' });
+    await git.branch({ fs, dir, ref: 'feature' });
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), '1\n2');
+    await git.add({ fs, dir, filepath: 'a.txt' });
+    await git.commit({ fs, dir, author, message: 'feat: update' });
+
+    const app = express();
+    app.set(appSettings.repo.description!, dir);
+    app.set(appSettings.branch.description!, 'HEAD');
+    app.use(createApiMiddlewareFromApp(app));
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+
+    const json = makeJsonFetcher(port);
+    const commitsHead = await fetchCommits(json);
+    expect(commitsHead[0].commit.message).toBe('feat: update\n');
+
+    app.set(appSettings.branch.description!, 'feature');
+    const commitsFeature = await fetchCommits(json);
+    expect(commitsFeature[0].commit.message).toBe('init\n');
 
     server.close();
   });

--- a/src/appSettings.ts
+++ b/src/appSettings.ts
@@ -1,0 +1,13 @@
+export const appSettings = {
+  repo: Symbol('repo'),
+  branch: Symbol('branch'),
+  ignore: Symbol('ignore'),
+} as const;
+
+export type AppSettingKey = typeof appSettings[keyof typeof appSettings];
+
+export interface AppSettings {
+  [appSettings.repo]?: string;
+  [appSettings.branch]?: string;
+  [appSettings.ignore]?: string[];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { Command } from 'commander';
-import { createApiMiddleware } from './apiMiddleware';
+import { createApiMiddlewareFromApp } from './apiMiddleware';
+import { appSettings } from './appSettings';
 
 const defaultIgnore = [
   '**/*.lock',
@@ -33,8 +34,11 @@ const { host, port, branch, ignore } = program.opts<{
 }>();
 
 const app = express();
+app.set(appSettings.branch.description!, branch);
+app.set(appSettings.ignore.description!, ignore);
+
 app.use(express.static('dist'));
-app.use(await createApiMiddleware({ branch, ignore }));
+app.use(createApiMiddlewareFromApp(app));
 
 app.listen(port, host, () => {
   console.log(`Server running at http://${host}:${port}`);


### PR DESCRIPTION
## Summary
- handle repo and branch dynamically via `createApiMiddlewareFromApp`
- remove `--repo` flag from CLI
- adjust server and tests for dynamic middleware
- use symbol keys for express settings

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684e8b018b70832ab724ba182dd1396b