### PR TITLE
Update ESLint config for type checking

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,12 +10,14 @@ const eslintrc = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',
-    sourceType: 'module'
+    sourceType: 'module',
+    project: './tsconfig.json'
   },
   plugins: ['@typescript-eslint'],
   extends: [
     'eslint:recommended',
-    'plugin:@typescript-eslint/recommended'
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking'
   ],
   rules: {
     semi: ['error', 'always'],

--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -21,7 +21,8 @@ describe('App commit log', () => {
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
         return Promise.resolve({ json: () => Promise.resolve([]) });
       }
-      return Promise.reject(new Error(`Unexpected url: ${input}`));
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      return Promise.reject(new Error(`Unexpected url: ${String(input)}`));
     }) as jest.Mock;
   });
 

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -18,7 +18,8 @@ describe('client index', () => {
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
         return Promise.resolve({ json: () => Promise.resolve([]) });
       }
-      return Promise.reject(new Error(`Unexpected url: ${input}`));
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      return Promise.reject(new Error(`Unexpected url: ${String(input)}`));
     }) as jest.Mock;
   });
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -28,7 +28,7 @@ export function App(): React.JSX.Element {
   const json = (input: string) => fetch(input).then((r) => r.json());
 
   useEffect(() => {
-    (async () => {
+    void (async () => {
       const commitData = await fetchCommits(json);
       setCommits(commitData);
       const s = commitData[commitData.length - 1].commit.committer.timestamp * 1000;
@@ -42,7 +42,7 @@ export function App(): React.JSX.Element {
 
   useEffect(() => {
     if (!ready) return;
-    (async () => {
+    void (async () => {
       const counts = await fetchLineCounts(json, timestamp);
       setLineCounts(counts);
       if (timestamp >= end) {

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -5,7 +5,9 @@ export default function viteExpress(): Plugin {
   return {
     name: 'vite-express',
     async configureServer(server) {
-      server.middlewares.use(await createApiMiddleware());
+      const middleware = await createApiMiddleware();
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      server.middlewares.use(middleware);
     },
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,11 @@
     "jsx": "react-jsx",
     "types": ["node", "react", "jest"]
   },
-  "include": ["src"],
+  "include": [
+    "src",
+    "vite.config.ts",
+    "playwright.config.ts",
+    "playwright"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- enable project-based linting with `tsconfig.json`
- extend recommended rules that require type information
- fix lint issues in tests and sources

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production --audit-level=moderate`


------
https://chatgpt.com/codex/tasks/task_e_684e8e636254832aa4cd5696d0d0aa33