### PR TITLE
feat(server): :recycle: inline api config

### DIFF
--- a/playwright/ui.spec.ts
+++ b/playwright/ui.spec.ts
@@ -5,7 +5,7 @@ import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import { test, expect } from '@playwright/test';
 import express from 'express';
-import { createApiMiddleware } from '../src/apiMiddleware';
+import { apiMiddleware } from '../src/apiMiddleware';
 
 const author = { name: 'a', email: 'a@example.com' };
 
@@ -17,8 +17,10 @@ test('serves index page', async ({ page }) => {
   await git.commit({ fs, dir, author, message: 'init' });
 
   const app = express();
+  app.set('repo', dir);
+  app.set('branch', 'HEAD');
   app.use(express.static('dist'));
-  app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
+  app.use(apiMiddleware);
   const server = app.listen(0);
   const { port } = server.address() as AddressInfo;
 

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import express from 'express';
-import { createApiMiddleware } from '../apiMiddleware';
+import { apiMiddleware } from '../apiMiddleware';
 import { fetchCommits, fetchLineCounts, JsonFetcher } from '../client/api';
 
 const author = { name: 'a', email: 'a@example.com' };
@@ -22,7 +22,9 @@ describe('server e2e', () => {
     await git.commit({ fs, dir, author, message: 'init' });
 
     const app = express();
-    app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
+    app.set('repo', dir);
+    app.set('branch', 'HEAD');
+    app.use(apiMiddleware);
     const server = app.listen(0);
     const { port } = server.address() as AddressInfo;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { Command } from 'commander';
-import { createApiMiddleware } from './apiMiddleware';
+import { apiMiddleware } from './apiMiddleware';
 
 const defaultIgnore = [
   '**/*.lock',
@@ -33,8 +33,10 @@ const { host, port, branch, ignore } = program.opts<{
 }>();
 
 const app = express();
+app.set('branch', branch);
+app.set('ignore', ignore);
 app.use(express.static('dist'));
-app.use(await createApiMiddleware({ branch, ignore }));
+app.use(apiMiddleware);
 
 app.listen(port, host, () => {
   console.log(`Server running at http://${host}:${port}`);

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,11 +1,11 @@
 import type { Plugin } from 'vite';
-import { createApiMiddleware } from './apiMiddleware';
+import { apiMiddleware } from './apiMiddleware';
 
 export default function viteExpress(): Plugin {
   return {
     name: 'vite-express',
-    async configureServer(server) {
-      server.middlewares.use(await createApiMiddleware());
+    configureServer(server) {
+      server.middlewares.use(apiMiddleware);
     },
   };
 }


### PR DESCRIPTION
## Summary
- inline repo/branch setup in route handlers
- update server/vite and tests to use apiMiddleware

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684e8f019bf0832aa576a692ad162c6c