### PR TITLE
Enable noUncheckedIndexedAccess

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -31,7 +31,7 @@ describe('server e2e', () => {
     const commits = await fetchCommits(json);
     const counts = await fetchLineCounts(json);
 
-    expect(commits[0].commit.message).toBe('init\n');
+    expect(commits[0]!.commit.message).toBe('init\n');
     expect(counts[0]?.file).toBe('a.txt');
 
     server.close();
@@ -57,11 +57,11 @@ describe('server e2e', () => {
 
     const json = makeJsonFetcher(port);
     const commitsHead = await fetchCommits(json);
-    expect(commitsHead[0].commit.message).toBe('feat: update\n');
+    expect(commitsHead[0]!.commit.message).toBe('feat: update\n');
 
     app.set(appSettings.branch.description!, 'feature');
     const commitsFeature = await fetchCommits(json);
-    expect(commitsFeature[0].commit.message).toBe('init\n');
+    expect(commitsFeature[0]!.commit.message).toBe('init\n');
 
     server.close();
   });

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,8 +31,8 @@ export function App(): React.JSX.Element {
     void (async () => {
       const commitData = await fetchCommits(json);
       setCommits(commitData);
-      const s = commitData[commitData.length - 1].commit.committer.timestamp * 1000;
-      const e = commitData[0].commit.committer.timestamp * 1000;
+      const s = commitData[commitData.length - 1]!.commit.committer.timestamp * 1000;
+      const e = commitData[0]!.commit.committer.timestamp * 1000;
       setStart(s);
       setEnd(e);
       setTimestamp(s);

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -33,7 +33,10 @@ export const CommitLog = ({ commits, seek, visible = 15 }: CommitLogProps): Reac
   const containerHeight = containerRef.current?.clientHeight ?? 1;
   const spanMs =
     slice.length > 1
-      ? (slice[0].commit.committer.timestamp - slice[slice.length - 1].commit.committer.timestamp) * 1000
+      ?
+          (slice[0]!.commit.committer.timestamp -
+            slice[slice.length - 1]!.commit.committer.timestamp) *
+          1000
       : 1;
   const msPerPx = spanMs / Math.max(containerHeight, 1);
 
@@ -49,9 +52,9 @@ export const CommitLog = ({ commits, seek, visible = 15 }: CommitLogProps): Reac
     const prevLi = current.previousElementSibling as HTMLLIElement | null;
     if (prevCommit && prevLi) {
       const diffMs =
-        (prevCommit.commit.committer.timestamp - commits[index].commit.committer.timestamp) * 1000;
+        (prevCommit.commit.committer.timestamp - commits[index]!.commit.committer.timestamp) * 1000;
       const ratio =
-        (timestamp - commits[index].commit.committer.timestamp * 1000) / diffMs;
+        (timestamp - commits[index]!.commit.committer.timestamp * 1000) / diffMs;
       const prevCenter = prevLi.offsetTop + prevLi.offsetHeight / 2;
       const currCenter = current.offsetTop + current.offsetHeight / 2;
       nextOffset -= (prevCenter - currCenter) * ratio;
@@ -70,7 +73,7 @@ export const CommitLog = ({ commits, seek, visible = 15 }: CommitLogProps): Reac
         {slice.map((c, i) => {
           const diff =
             i > 0
-              ? (slice[i - 1].commit.committer.timestamp - c.commit.committer.timestamp) * 1000
+              ? (slice[i - 1]!.commit.committer.timestamp - c.commit.committer.timestamp) * 1000
               : 0;
           const marginTop = i > 0 ? `${diff / msPerPx}px` : undefined;
           const isCurrent = start + i === index;

--- a/src/client/lines.tsx
+++ b/src/client/lines.tsx
@@ -183,7 +183,7 @@ export const createFileSimulation = (
         y: Math.random() * height - y,
       };
       spawnChar(info.charsEl, 'add-char', offset, () => {
-        displayCounts[file]++;
+        displayCounts[file] = (displayCounts[file] ?? 0) + 1;
         info.handle.setCount(displayCounts[file]);
       });
     }
@@ -193,7 +193,7 @@ export const createFileSimulation = (
         y: Math.random() * window.innerHeight - (rect.top + y),
       };
       spawnChar(info.charsEl, 'remove-char', offset, () => {
-        displayCounts[file]--;
+        displayCounts[file] = (displayCounts[file] ?? 0) - 1;
         info.handle.setCount(displayCounts[file]);
       });
     }
@@ -244,7 +244,12 @@ export const createFileSimulation = (
 
   const update = (data: LineCount[]): void => {
     currentData = data;
-    const scale = computeScale(width, height, data, { linear: opts.linear });
+    const scale = computeScale(
+      width,
+      height,
+      data,
+      opts.linear !== undefined ? { linear: opts.linear } : {},
+    );
     const exp = opts.linear ? 1 : 0.5;
     const names = new Set(data.map((d) => d.file));
     for (const [name, info] of Object.entries(bodies)) {
@@ -320,8 +325,8 @@ export const createFileSimulation = (
         };
         displayCounts[file.file] = lines;
         Composite.add(engine.world, body);
-        spawnChars(bodies[file.file], file.file, added, removed);
-        if (effectsEnabled) bodies[file.file].handle.showGlow('glow-new');
+        spawnChars(bodies[file.file]!, file.file, added, removed);
+        if (effectsEnabled) bodies[file.file]!.handle.showGlow('glow-new');
       }
     }
   };

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from 'vite';
+import type { NextHandleFunction } from 'connect';
 import { createApiMiddleware } from './apiMiddleware';
 
 export default function viteExpress(): Plugin {
@@ -7,7 +8,7 @@ export default function viteExpress(): Plugin {
     async configureServer(server) {
       const middleware = await createApiMiddleware();
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      server.middlewares.use(middleware);
+      server.middlewares.use(middleware as unknown as NextHandleFunction);
     },
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "types": ["node", "react", "jest"]


### PR DESCRIPTION
## Summary
- enable `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`
- adjust tests and code for stricter TypeScript settings
- cast express middleware for vite

## Testing
- `npm run lint` *(fails: Unsafe return type any in existing code)*
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684e90565f28832ab7645a86508e9c68