### PR TITLE
Refactor commit log API

### DIFF
--- a/src/__tests__/commitLog.test.tsx
+++ b/src/__tests__/commitLog.test.tsx
@@ -1,24 +1,20 @@
 /** @jest-environment jsdom */
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { CommitLog } from '../client/components/CommitLog';
 import type { Commit } from '../client/types';
 
 describe('CommitLog', () => {
-  it('highlights current commit on input', () => {
-    document.body.innerHTML = '<input id="seek" />';
-    const seek = document.getElementById('seek') as HTMLInputElement;
+  it('highlights current commit when timestamp changes', () => {
     const commits: Commit[] = [
       { commit: { message: 'new', committer: { timestamp: 2 } } },
       { commit: { message: 'old', committer: { timestamp: 1 } } },
     ];
-    seek.value = '1500';
-    const { container } = render(<CommitLog commits={commits} seek={seek} visible={2} />);
+    const { container, rerender } = render(
+      <CommitLog commits={commits} timestamp={1500} visible={2} />,
+    );
     expect(container.querySelector('li.current')?.textContent).toBe('old');
-    act(() => {
-      seek.value = '2500';
-      seek.dispatchEvent(new Event('input'));
-    });
+    rerender(<CommitLog commits={commits} timestamp={2500} visible={2} />);
     expect(container.querySelector('li.current')?.textContent).toBe('new');
     expect(container.querySelectorAll('li').length).toBeGreaterThanOrEqual(1);
   });

--- a/src/apiMiddleware.ts
+++ b/src/apiMiddleware.ts
@@ -72,7 +72,8 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
   const repoDir = (): string =>
     path.resolve((app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd());
 
-  const ignorePatterns = (): string[] => app.get(appSettings.ignore.description!) ?? [];
+  const ignorePatterns = (): string[] =>
+    (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [];
 
   router.get('/api/commits', async (_req, res) => {
     const dir = repoDir();
@@ -81,7 +82,10 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
       return;
     }
     try {
-      const branch = await resolveBranch(dir, app.get(appSettings.branch.description!));
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
       const commits = await git.log({ fs, dir, ref: branch });
       res.json(commits);
     } catch (error) {
@@ -96,7 +100,10 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
       return;
     }
     try {
-      const branch = await resolveBranch(dir, app.get(appSettings.branch.description!));
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
       const tsParam = req.query.ts as string | undefined;
       const ignore = ignorePatterns();
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -19,7 +19,6 @@ export function App(): React.JSX.Element {
   const [ready, setReady] = useState(false);
 
   const seekRef = useRef<HTMLInputElement>(null);
-  const [seek, setSeek] = useState<HTMLInputElement | null>(null);
   const durationRef = useRef<HTMLInputElement>(null);
   const playerRef = useRef<PlayButtonHandle>(null);
   const simRef = useRef<SimulationAreaHandle>(null);
@@ -83,7 +82,6 @@ export function App(): React.JSX.Element {
           <SeekBar
             ref={(el) => {
               seekRef.current = el;
-              setSeek(el);
             }}
             onInput={setTimestamp}
           />
@@ -94,7 +92,11 @@ export function App(): React.JSX.Element {
       {ready && (
         <>
           <SimulationArea ref={simRef} data={lineCounts} />
-          {seek && <CommitLog commits={commits} seek={seek} />}
+          <CommitLog
+            commits={commits}
+            timestamp={timestamp}
+            onTimestampChange={setTimestamp}
+          />
         </>
       )}
     </>

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -3,22 +3,16 @@ import type { Commit } from '../types';
 
 export interface CommitLogProps {
   commits: Commit[];
-  seek: HTMLInputElement;
+  timestamp: number;
+  onTimestampChange?: (n: number) => void;
   visible?: number;
 }
 
-export const CommitLog = ({ commits, seek, visible = 15 }: CommitLogProps): React.JSX.Element => {
+export const CommitLog = ({ commits, timestamp, visible = 15 }: CommitLogProps): React.JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
-  const [timestamp, setTimestamp] = useState(() => Number(seek.value));
   const [offset, setOffset] = useState(0);
 
-  useEffect(() => {
-    const onInput = () => setTimestamp(Number(seek.value));
-    seek.addEventListener('input', onInput);
-    onInput();
-    return () => seek.removeEventListener('input', onInput);
-  }, [seek]);
 
   const index = useMemo(() => {
     let idx = commits.findIndex((c) => c.commit.committer.timestamp * 1000 <= timestamp);


### PR DESCRIPTION
## Summary
- control `CommitLog` using timestamp rather than DOM input
- wire `App` to pass timestamp state to `CommitLog`
- fix API middleware typings for lint
- update `CommitLog` tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e912c70bc832ab13203577dc19170