### PR TITLE
feat(client): refactor player api

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -3,22 +3,18 @@ import { createPlayer } from '../client/player';
 
 describe('createPlayer', () => {
   it('toggles playback and calls raf', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '20';
-
+    let seek = 0;
     const raf = jest.fn();
     const now = jest.fn(() => 0);
 
     createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 20,
       playButton,
       start: 0,
       end: 10,
@@ -33,65 +29,56 @@ describe('createPlayer', () => {
     playButton.click();
     expect(playButton.textContent).toBe('Play');
   });
+
   it('advances to end and stops', () => {
-    document.body.innerHTML = `
-    <button id="play"></button>
-    <input id="seek" />
-    <input id="duration" />
-  `;
-  const playButton = document.getElementById('play') as HTMLButtonElement;
-  const seek = document.getElementById('seek') as HTMLInputElement;
-  const duration = document.getElementById('duration') as HTMLInputElement;
-  duration.value = '1';
-
-  const callbacks: FrameRequestCallback[] = [];
-  const raf = (cb: FrameRequestCallback) => {
-    callbacks.push(cb);
-    return 1;
-  };
-
-  const player = createPlayer({
-    seek,
-    duration,
-    playButton,
-    start: 0,
-    end: 5,
-    raf,
-    now: () => 0,
-  });
-
-  player.togglePlay();
-  callbacks[0]?.(0);
-  callbacks[1]?.(500);
-  callbacks[2]?.(1000);
-
-  expect(seek.value).toBe('5');
-  expect(playButton.textContent).toBe('Play');
-  });
-
-  it('dispatches input events during playback', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
-
+    let seek = 0;
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback) => {
       callbacks.push(cb);
       return 1;
     };
 
-    const listener = jest.fn();
-    seek.addEventListener('input', listener);
+    const player = createPlayer({
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 1,
+      playButton,
+      start: 0,
+      end: 5,
+      raf,
+      now: () => 0,
+    });
+
+    player.togglePlay();
+    callbacks[0]?.(0);
+    callbacks[1]?.(500);
+    callbacks[2]?.(1000);
+
+    expect(seek).toBe(5);
+    expect(playButton.textContent).toBe('Play');
+  });
+
+  it('calls setSeek during playback', () => {
+    document.body.innerHTML = '<button id="play"></button>';
+    const playButton = document.getElementById('play') as HTMLButtonElement;
+    let seek = 0;
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback) => {
+      callbacks.push(cb);
+      return 1;
+    };
+    const setSeek = jest.fn((v: number) => {
+      seek = v;
+    });
 
     const player = createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek,
+      duration: 1,
       playButton,
       start: 0,
       end: 2,
@@ -103,25 +90,21 @@ describe('createPlayer', () => {
     callbacks[0]?.(0);
     callbacks[1]?.(1000);
 
-    expect(listener).toHaveBeenCalled();
+    expect(setSeek).toHaveBeenCalled();
   });
 
   it('pauses and resumes playback', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
-
+    let seek = 0;
     const raf = jest.fn();
 
     const player = createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 1,
       playButton,
       start: 0,
       end: 2,
@@ -132,23 +115,20 @@ describe('createPlayer', () => {
     player.resume();
     expect(playButton.textContent).toBe('Pause');
     player.pause();
-  expect(playButton.textContent).toBe('Play');
+    expect(playButton.textContent).toBe('Play');
   });
 
   it('stops and resets', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    let seek = 1;
 
     const player = createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 1,
       playButton,
       start: 0,
       end: 2,
@@ -156,27 +136,23 @@ describe('createPlayer', () => {
       now: () => 0,
     });
 
-    seek.value = '1';
     player.stop();
-    expect(seek.value).toBe('0');
+    expect(seek).toBe(0);
     expect(playButton.textContent).toBe('Play');
   });
 
   it('resets when playing from end', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
-
+    let seek = 2;
     const raf = jest.fn();
+
     createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 1,
       playButton,
       start: 0,
       end: 2,
@@ -184,34 +160,28 @@ describe('createPlayer', () => {
       now: () => 0,
     });
 
-    seek.value = '2';
     playButton.click();
-    expect(seek.value).toBe('0');
+    expect(seek).toBe(0);
     expect(playButton.textContent).toBe('Pause');
   });
 
   it('notifies play state changes', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
+    document.body.innerHTML = '<button id="play"></button>';
     const playButton = document.getElementById('play') as HTMLButtonElement;
-    const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
-
+    let seek = 0;
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback) => {
       callbacks.push(cb);
       return 1;
     };
-
     const stateListener = jest.fn();
 
     const player = createPlayer({
-      seek,
-      duration,
+      getSeek: () => seek,
+      setSeek: (v) => {
+        seek = v;
+      },
+      duration: 1,
       playButton,
       start: 0,
       end: 2,

--- a/src/apiMiddleware.ts
+++ b/src/apiMiddleware.ts
@@ -72,7 +72,8 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
   const repoDir = (): string =>
     path.resolve((app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd());
 
-  const ignorePatterns = (): string[] => app.get(appSettings.ignore.description!) ?? [];
+  const ignorePatterns = (): string[] =>
+    (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [];
 
   router.get('/api/commits', async (_req, res) => {
     const dir = repoDir();
@@ -81,7 +82,10 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
       return;
     }
     try {
-      const branch = await resolveBranch(dir, app.get(appSettings.branch.description!));
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
       const commits = await git.log({ fs, dir, ref: branch });
       res.json(commits);
     } catch (error) {
@@ -96,7 +100,10 @@ export const createApiMiddlewareFromApp = (app: Application): express.Router => 
       return;
     }
     try {
-      const branch = await resolveBranch(dir, app.get(appSettings.branch.description!));
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
       const tsParam = req.query.ts as string | undefined;
       const ignore = ignorePatterns();
 

--- a/src/client/components/PlayButton.tsx
+++ b/src/client/components/PlayButton.tsx
@@ -1,34 +1,9 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { usePlayer } from '../hooks';
-
-export interface PlayButtonHandle {
-  stop: () => void;
-  pause: () => void;
-  resume: () => void;
-  isPlaying: () => boolean;
-}
+import React from 'react';
 
 export interface PlayButtonProps {
-  seekRef: React.RefObject<HTMLInputElement | null>;
-  durationRef: React.RefObject<HTMLInputElement | null>;
-  start: number;
-  end: number;
-  onPlayStateChange: (playing: boolean) => void;
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
 }
 
-export const PlayButton = forwardRef<PlayButtonHandle, PlayButtonProps>(
-  ({ seekRef, durationRef, start, end, onPlayStateChange }, ref) => {
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    const { stop, pause, resume, isPlaying } = usePlayer(buttonRef, {
-      seekRef: seekRef as React.RefObject<HTMLInputElement>,
-      durationRef: durationRef as React.RefObject<HTMLInputElement>,
-      start,
-      end,
-      onPlayStateChange,
-    });
-
-    useImperativeHandle(ref, () => ({ stop, pause, resume, isPlaying }));
-
-    return <button ref={buttonRef}>Play</button>;
-  },
+export const PlayButton = ({ buttonRef }: PlayButtonProps): React.JSX.Element => (
+  <button ref={buttonRef}>Play</button>
 );

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -61,25 +61,28 @@ export const useAnimatedSimulation = (
 
 export const usePlayer = (
   buttonRef: React.RefObject<HTMLButtonElement | null>,
-  options: Omit<PlayerOptions, 'playButton' | 'seek' | 'duration'> & {
-    seekRef: React.RefObject<HTMLInputElement | null>;
-    durationRef: React.RefObject<HTMLInputElement | null>;
-  },
+  options: Omit<PlayerOptions, 'playButton'>,
 ) => {
-  const { seekRef, durationRef, ...opts } = options;
+  const { getSeek, setSeek, duration, start, end, raf, now, onPlayStateChange } =
+    options;
   const playerRef = useRef<ReturnType<typeof createPlayer> | null>(null);
 
   useEffect(() => {
-    if (!buttonRef.current || !seekRef.current || !durationRef.current) return;
+    if (!buttonRef.current) return;
     const player = createPlayer({
-      seek: seekRef.current,
-      duration: durationRef.current,
+      getSeek,
+      setSeek,
+      duration,
       playButton: buttonRef.current,
-      ...opts,
+      start,
+      end,
+      raf,
+      now,
+      onPlayStateChange,
     });
     playerRef.current = player;
     return () => player.pause();
-  }, [buttonRef, seekRef, durationRef, opts]);
+  }, [buttonRef, getSeek, setSeek, duration, start, end, raf, now, onPlayStateChange]);
 
   const stop = useCallback(() => playerRef.current?.stop(), []);
   const pause = useCallback(() => playerRef.current?.pause(), []);

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -1,6 +1,7 @@
 export interface PlayerOptions {
-  seek: HTMLInputElement;
-  duration: HTMLInputElement;
+  getSeek: () => number;
+  setSeek: (value: number) => void;
+  duration: number;
   playButton: HTMLButtonElement;
   start: number;
   end: number;
@@ -10,7 +11,8 @@ export interface PlayerOptions {
 }
 
 export const createPlayer = ({
-  seek,
+  getSeek,
+  setSeek,
   duration,
   playButton,
   start,
@@ -28,13 +30,12 @@ export const createPlayer = ({
       raf(tick);
       return;
     }
-    const total = parseFloat(duration.value) * 1000;
+    const total = duration * 1000;
     const factor = (end - start) / total;
     const dt = (time - lastTime) * factor;
     lastTime = time;
-    const next = Math.min(Number(seek.value) + dt, end);
-    seek.value = String(next);
-    seek.dispatchEvent(new Event('input'));
+    const next = Math.min(getSeek() + dt, end);
+    setSeek(next);
     if (next < end) {
       raf(tick);
     } else {
@@ -48,16 +49,15 @@ export const createPlayer = ({
     if (playing) {
       lastTime = now();
       raf(tick);
-    } else if (Number(seek.value) >= end) {
-      console.log('[debug] seekbar final update processed at', seek.value);
+    } else if (getSeek() >= end) {
+      console.log('[debug] seekbar final update processed at', getSeek());
     }
     onPlayStateChange?.(playing);
   };
 
   const togglePlay = (): void => {
-    if (!playing && Number(seek.value) >= end) {
-      seek.value = String(start);
-      seek.dispatchEvent(new Event('input'));
+    if (!playing && getSeek() >= end) {
+      setSeek(start);
     }
     setPlaying(!playing);
   };
@@ -65,18 +65,14 @@ export const createPlayer = ({
   const pause = (): void => setPlaying(false);
   const stop = (): void => {
     setPlaying(false);
-    seek.value = String(start);
-    seek.dispatchEvent(new Event('input'));
+    setSeek(start);
   };
   const resume = (): void => setPlaying(true);
   const isPlaying = (): boolean => playing;
 
   playButton.addEventListener('click', togglePlay);
 
-  seek.min = String(start);
-  seek.max = String(end);
-  seek.value = String(start);
-  seek.dispatchEvent(new Event('input'));
+  setSeek(start);
 
   return { togglePlay, pause, resume, stop, isPlaying };
 };


### PR DESCRIPTION
## Summary
- rework PlayerOptions to use callbacks instead of DOM refs
- update player implementation for new callbacks
- adjust usePlayer hook and PlayButton component
- manage player directly in App
- fix middleware type issues and update tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e913efed4832ab8d4d9e8d06c425f