### PR TITLE
Add typecheck step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run lint
       - run: npm test
       - uses: actions/cache@v3

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "vite",
     "test": "jest",
     "test:playwright": "playwright test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "rename-demo": "tsx src/renameDemo.ts"
   },
   "dependencies": {

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -7,7 +7,6 @@ export default function viteExpress(): Plugin {
     name: 'vite-express',
     async configureServer(server) {
       const middleware = await createApiMiddleware();
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       server.middlewares.use(middleware as unknown as NextHandleFunction);
     },
   };


### PR DESCRIPTION
## Summary
- add a typecheck npm script
- run `npm run typecheck` in the CI workflow
- remove unused ESLint directive

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684e92855f98832aa8b69013d74c97db