### PR TITLE
feat: commit log controlled by timestamp

### DIFF
--- a/src/__tests__/commitLog.test.tsx
+++ b/src/__tests__/commitLog.test.tsx
@@ -5,19 +5,17 @@ import { CommitLog } from '../client/components/CommitLog';
 import type { Commit } from '../client/types';
 
 describe('CommitLog', () => {
-  it('highlights current commit on input', () => {
-    document.body.innerHTML = '<input id="seek" />';
-    const seek = document.getElementById('seek') as HTMLInputElement;
+  it('highlights current commit on timestamp change', () => {
     const commits: Commit[] = [
       { commit: { message: 'new', committer: { timestamp: 2 } } },
       { commit: { message: 'old', committer: { timestamp: 1 } } },
     ];
-    seek.value = '1500';
-    const { container } = render(<CommitLog commits={commits} seek={seek} visible={2} />);
+    const { container, rerender } = render(
+      <CommitLog commits={commits} timestamp={1500} visible={2} />,
+    );
     expect(container.querySelector('li.current')?.textContent).toBe('old');
     act(() => {
-      seek.value = '2500';
-      seek.dispatchEvent(new Event('input'));
+      rerender(<CommitLog commits={commits} timestamp={2500} visible={2} />);
     });
     expect(container.querySelector('li.current')?.textContent).toBe('new');
     expect(container.querySelectorAll('li').length).toBeGreaterThanOrEqual(1);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -19,7 +19,6 @@ export function App(): React.JSX.Element {
   const [ready, setReady] = useState(false);
 
   const seekRef = useRef<HTMLInputElement | null>(null);
-  const [seek, setSeek] = useState<HTMLInputElement | null>(null);
   const durationRef = useRef<HTMLInputElement>(null);
   const playerRef = useRef<PlayButtonHandle>(null);
   const simRef = useRef<SimulationAreaHandle>(null);
@@ -69,9 +68,7 @@ export function App(): React.JSX.Element {
 
   useEffect(() => {
     if (!ready) return;
-    const el = document.querySelector<HTMLInputElement>('input[type="range"]');
-    seekRef.current = el;
-    setSeek(el);
+    seekRef.current = document.querySelector<HTMLInputElement>('input[type="range"]');
   }, [ready]);
 
   return (
@@ -95,7 +92,11 @@ export function App(): React.JSX.Element {
       {ready && (
         <>
           <SimulationArea ref={simRef} data={lineCounts} />
-          {seek && <CommitLog commits={commits} seek={seek} />}
+          <CommitLog
+            commits={commits}
+            timestamp={timestamp}
+            onTimestampChange={setTimestamp}
+          />
         </>
       )}
     </>

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -3,22 +3,20 @@ import type { Commit } from '../types';
 
 export interface CommitLogProps {
   commits: Commit[];
-  seek: HTMLInputElement;
+  timestamp: number;
+  onTimestampChange?: (n: number) => void;
   visible?: number;
 }
 
-export const CommitLog = ({ commits, seek, visible = 15 }: CommitLogProps): React.JSX.Element => {
+export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 }: CommitLogProps): React.JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
-  const [timestamp, setTimestamp] = useState(() => Number(seek.value));
   const [offset, setOffset] = useState(0);
 
   useEffect(() => {
-    const onInput = () => setTimestamp(Number(seek.value));
-    seek.addEventListener('input', onInput);
-    onInput();
-    return () => seek.removeEventListener('input', onInput);
-  }, [seek]);
+    onTimestampChange?.(timestamp);
+  }, [timestamp, onTimestampChange]);
+
 
   const index = useMemo(() => {
     let idx = commits.findIndex((c) => c.commit.committer.timestamp * 1000 <= timestamp);

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -7,7 +7,6 @@ export default function viteExpress(): Plugin {
     name: 'vite-express',
     async configureServer(server) {
       const middleware = await createApiMiddleware();
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       server.middlewares.use(middleware as unknown as NextHandleFunction);
     },
   };


### PR DESCRIPTION
## Summary
- update `CommitLog` to use `timestamp` prop and optional `onTimestampChange`
- remove listener side-effect
- adjust `App` and tests for new API
- drop unused ESLint directive in `viteExpress`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e92cad654832aa27e903cdea3748e