### PR TITLE
Add hook tests and raise coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,8 +16,7 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      // TODO: increase back to 80 once hook tests are expanded
-      lines: 79,
+      lines: 80,
     },
   },
 };

--- a/src/__tests__/useFileSimulation.test.ts
+++ b/src/__tests__/useFileSimulation.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useFileSimulation } from '../client/hooks';
+import { createFileSimulation } from '../client/lines';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+describe('useFileSimulation', () => {
+  beforeEach(() => {
+    (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes simulation and forwards controls', () => {
+    const container = document.createElement('div');
+    const ref = { current: container } as React.RefObject<HTMLDivElement>;
+
+    const { result } = renderHook(() => useFileSimulation(ref));
+
+    expect(createFileSimulation).toHaveBeenCalledWith(container, {});
+
+    act(() => {
+      result.current.update([]);
+      result.current.pause();
+      result.current.resume();
+      result.current.setEffectsEnabled(true);
+    });
+
+    expect(mockSim.update).toHaveBeenCalledWith([]);
+    expect(mockSim.pause).toHaveBeenCalled();
+    expect(mockSim.resume).toHaveBeenCalled();
+    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('cleans up on unmount', () => {
+    const container = document.createElement('div');
+    const ref = { current: container } as React.RefObject<HTMLDivElement>;
+
+    const { unmount } = renderHook(() => useFileSimulation(ref));
+    unmount();
+
+    expect(mockSim.destroy).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/usePlayer.test.ts
+++ b/src/__tests__/usePlayer.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { usePlayer } from '../client/hooks';
+import { createPlayer } from '../client/player';
+
+jest.mock('../client/player');
+
+describe('usePlayer', () => {
+  const mockPlayer = {
+    stop: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    isPlaying: jest.fn(() => true),
+  };
+
+  beforeEach(() => {
+    (createPlayer as jest.Mock).mockReturnValue(mockPlayer);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates player and exposes controls', () => {
+    const button = document.createElement('button');
+    const seek = document.createElement('input');
+    const duration = document.createElement('input');
+    const buttonRef = { current: button } as React.RefObject<HTMLButtonElement>;
+    const seekRef = { current: seek } as React.RefObject<HTMLInputElement>;
+    const durationRef = { current: duration } as React.RefObject<HTMLInputElement>;
+
+    const { result } = renderHook(() =>
+      usePlayer(buttonRef, { seekRef, durationRef, start: 0, end: 10 }),
+    );
+
+    expect(createPlayer).toHaveBeenCalledWith({
+      seek,
+      duration,
+      playButton: button,
+      start: 0,
+      end: 10,
+    });
+
+    act(() => {
+      result.current.pause();
+      result.current.resume();
+      result.current.stop();
+    });
+
+    expect(mockPlayer.pause).toHaveBeenCalled();
+    expect(mockPlayer.resume).toHaveBeenCalled();
+    expect(mockPlayer.stop).toHaveBeenCalled();
+    expect(result.current.isPlaying()).toBe(true);
+  });
+
+  it('pauses on unmount', () => {
+    const button = document.createElement('button');
+    const seek = document.createElement('input');
+    const duration = document.createElement('input');
+    const buttonRef = { current: button } as React.RefObject<HTMLButtonElement>;
+    const seekRef = { current: seek } as React.RefObject<HTMLInputElement>;
+    const durationRef = { current: duration } as React.RefObject<HTMLInputElement>;
+
+    const { unmount } = renderHook(() =>
+      usePlayer(buttonRef, { seekRef, durationRef, start: 0, end: 10 }),
+    );
+    unmount();
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `useFileSimulation`
- add unit tests for `usePlayer`
- raise Jest coverage threshold back to 80%

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=moderate`


------
https://chatgpt.com/codex/tasks/task_e_684e935312e4832aa78ea7149d41551c