### PR TITLE
codex/player-api

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -3,47 +3,38 @@ import { createPlayer } from '../client/player';
 
 describe('createPlayer', () => {
   it('toggles playback and calls raf', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '20';
+    seek.value = '0';
 
     const raf = jest.fn();
     const now = jest.fn(() => 0);
 
-    createPlayer({
-      seek,
-      duration,
-      playButton,
+    const player = createPlayer({
+      getSeek: () => Number(seek.value),
+      setSeek: (v) => {
+        seek.value = String(v);
+        seek.dispatchEvent(new Event('input'));
+      },
+      duration: 20,
       start: 0,
       end: 10,
       raf,
       now,
     });
 
-    playButton.click();
-    expect(playButton.textContent).toBe('Pause');
+    player.togglePlay();
+    expect(player.isPlaying()).toBe(true);
     expect(raf).toHaveBeenCalled();
 
-    playButton.click();
-    expect(playButton.textContent).toBe('Play');
+    player.togglePlay();
+    expect(player.isPlaying()).toBe(false);
   });
   it('advances to end and stops', () => {
-    document.body.innerHTML = `
-    <button id="play"></button>
-    <input id="seek" />
-    <input id="duration" />
-  `;
-  const playButton = document.getElementById('play') as HTMLButtonElement;
-  const seek = document.getElementById('seek') as HTMLInputElement;
-  const duration = document.getElementById('duration') as HTMLInputElement;
-  duration.value = '1';
-
+    document.body.innerHTML = '<input id="seek" />';
+    const seek = document.getElementById('seek') as HTMLInputElement;
+    seek.value = '0';
+  
   const callbacks: FrameRequestCallback[] = [];
   const raf = (cb: FrameRequestCallback) => {
     callbacks.push(cb);
@@ -51,9 +42,12 @@ describe('createPlayer', () => {
   };
 
   const player = createPlayer({
-    seek,
-    duration,
-    playButton,
+    getSeek: () => Number(seek.value),
+    setSeek: (v) => {
+      seek.value = String(v);
+      seek.dispatchEvent(new Event('input'));
+    },
+    duration: 1,
     start: 0,
     end: 5,
     raf,
@@ -66,19 +60,13 @@ describe('createPlayer', () => {
   callbacks[2]?.(1000);
 
   expect(seek.value).toBe('5');
-  expect(playButton.textContent).toBe('Play');
+  expect(player.isPlaying()).toBe(false);
   });
 
   it('dispatches input events during playback', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    seek.value = '0';
 
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback) => {
@@ -89,40 +77,40 @@ describe('createPlayer', () => {
     const listener = jest.fn();
     seek.addEventListener('input', listener);
 
-    const player = createPlayer({
-      seek,
-      duration,
-      playButton,
-      start: 0,
-      end: 2,
-      raf,
-      now: () => 0,
-    });
+      const player = createPlayer({
+        getSeek: () => Number(seek.value),
+        setSeek: (v) => {
+          seek.value = String(v);
+          seek.dispatchEvent(new Event('input'));
+        },
+        duration: 1,
+        start: 0,
+        end: 2,
+        raf,
+        now: () => 0,
+      });
 
-    player.togglePlay();
-    callbacks[0]?.(0);
-    callbacks[1]?.(1000);
+      player.togglePlay();
+      callbacks[0]?.(0);
+      callbacks[1]?.(1000);
 
     expect(listener).toHaveBeenCalled();
   });
 
   it('pauses and resumes playback', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    seek.value = '0';
 
     const raf = jest.fn();
 
     const player = createPlayer({
-      seek,
-      duration,
-      playButton,
+      getSeek: () => Number(seek.value),
+      setSeek: (v) => {
+        seek.value = String(v);
+        seek.dispatchEvent(new Event('input'));
+      },
+      duration: 1,
       start: 0,
       end: 2,
       raf,
@@ -130,76 +118,62 @@ describe('createPlayer', () => {
     });
 
     player.resume();
-    expect(playButton.textContent).toBe('Pause');
+    expect(player.isPlaying()).toBe(true);
     player.pause();
-  expect(playButton.textContent).toBe('Play');
+    expect(player.isPlaying()).toBe(false);
   });
 
   it('stops and resets', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    seek.value = '1';
 
     const player = createPlayer({
-      seek,
-      duration,
-      playButton,
+      getSeek: () => Number(seek.value),
+      setSeek: (v) => {
+        seek.value = String(v);
+        seek.dispatchEvent(new Event('input'));
+      },
+      duration: 1,
       start: 0,
       end: 2,
       raf: jest.fn(),
       now: () => 0,
     });
 
-    seek.value = '1';
     player.stop();
     expect(seek.value).toBe('0');
-    expect(playButton.textContent).toBe('Play');
+    expect(player.isPlaying()).toBe(false);
   });
 
   it('resets when playing from end', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    seek.value = '2';
 
     const raf = jest.fn();
-    createPlayer({
-      seek,
-      duration,
-      playButton,
+    const player = createPlayer({
+      getSeek: () => Number(seek.value),
+      setSeek: (v) => {
+        seek.value = String(v);
+        seek.dispatchEvent(new Event('input'));
+      },
+      duration: 1,
       start: 0,
       end: 2,
       raf,
       now: () => 0,
     });
 
-    seek.value = '2';
-    playButton.click();
+    player.togglePlay();
     expect(seek.value).toBe('0');
-    expect(playButton.textContent).toBe('Pause');
+    expect(player.isPlaying()).toBe(true);
   });
 
   it('notifies play state changes', () => {
-    document.body.innerHTML = `
-      <button id="play"></button>
-      <input id="seek" />
-      <input id="duration" />
-    `;
-    const playButton = document.getElementById('play') as HTMLButtonElement;
+    document.body.innerHTML = '<input id="seek" />';
     const seek = document.getElementById('seek') as HTMLInputElement;
-    const duration = document.getElementById('duration') as HTMLInputElement;
-    duration.value = '1';
+    seek.value = '0';
 
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback) => {
@@ -210,9 +184,12 @@ describe('createPlayer', () => {
     const stateListener = jest.fn();
 
     const player = createPlayer({
-      seek,
-      duration,
-      playButton,
+      getSeek: () => Number(seek.value),
+      setSeek: (v) => {
+        seek.value = String(v);
+        seek.dispatchEvent(new Event('input'));
+      },
+      duration: 1,
       start: 0,
       end: 2,
       raf,

--- a/src/client/components/PlayButton.tsx
+++ b/src/client/components/PlayButton.tsx
@@ -1,34 +1,10 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { usePlayer } from '../hooks';
-
-export interface PlayButtonHandle {
-  stop: () => void;
-  pause: () => void;
-  resume: () => void;
-  isPlaying: () => boolean;
-}
+import React from 'react';
 
 export interface PlayButtonProps {
-  seekRef: React.RefObject<HTMLInputElement | null>;
-  durationRef: React.RefObject<HTMLInputElement | null>;
-  start: number;
-  end: number;
-  onPlayStateChange: (playing: boolean) => void;
+  playing: boolean;
+  onToggle: () => void;
 }
 
-export const PlayButton = forwardRef<PlayButtonHandle, PlayButtonProps>(
-  ({ seekRef, durationRef, start, end, onPlayStateChange }, ref) => {
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    const { stop, pause, resume, isPlaying } = usePlayer(buttonRef, {
-      seekRef: seekRef as React.RefObject<HTMLInputElement>,
-      durationRef: durationRef as React.RefObject<HTMLInputElement>,
-      start,
-      end,
-      onPlayStateChange,
-    });
-
-    useImperativeHandle(ref, () => ({ stop, pause, resume, isPlaying }));
-
-    return <button ref={buttonRef}>Play</button>;
-  },
-);
+export function PlayButton({ playing, onToggle }: PlayButtonProps): React.JSX.Element {
+  return <button onClick={onToggle}>{playing ? 'Pause' : 'Play'}</button>;
+}

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -1,7 +1,7 @@
 export interface PlayerOptions {
-  seek: HTMLInputElement;
-  duration: HTMLInputElement;
-  playButton: HTMLButtonElement;
+  getSeek: () => number;
+  setSeek: (value: number) => void;
+  duration: number;
   start: number;
   end: number;
   raf?: (cb: FrameRequestCallback) => number;
@@ -10,9 +10,9 @@ export interface PlayerOptions {
 }
 
 export const createPlayer = ({
-  seek,
+  getSeek,
+  setSeek,
   duration,
-  playButton,
   start,
   end,
   raf = requestAnimationFrame,
@@ -28,13 +28,12 @@ export const createPlayer = ({
       raf(tick);
       return;
     }
-    const total = parseFloat(duration.value) * 1000;
+    const total = duration * 1000;
     const factor = (end - start) / total;
     const dt = (time - lastTime) * factor;
     lastTime = time;
-    const next = Math.min(Number(seek.value) + dt, end);
-    seek.value = String(next);
-    seek.dispatchEvent(new Event('input'));
+    const next = Math.min(getSeek() + dt, end);
+    setSeek(next);
     if (next < end) {
       raf(tick);
     } else {
@@ -44,20 +43,18 @@ export const createPlayer = ({
 
   const setPlaying = (state: boolean) => {
     playing = state;
-    playButton.textContent = playing ? 'Pause' : 'Play';
     if (playing) {
       lastTime = now();
       raf(tick);
-    } else if (Number(seek.value) >= end) {
-      console.log('[debug] seekbar final update processed at', seek.value);
+    } else if (getSeek() >= end) {
+      console.log('[debug] seekbar final update processed at', getSeek());
     }
     onPlayStateChange?.(playing);
   };
 
   const togglePlay = (): void => {
-    if (!playing && Number(seek.value) >= end) {
-      seek.value = String(start);
-      seek.dispatchEvent(new Event('input'));
+    if (!playing && getSeek() >= end) {
+      setSeek(start);
     }
     setPlaying(!playing);
   };
@@ -65,18 +62,12 @@ export const createPlayer = ({
   const pause = (): void => setPlaying(false);
   const stop = (): void => {
     setPlaying(false);
-    seek.value = String(start);
-    seek.dispatchEvent(new Event('input'));
+    setSeek(start);
   };
   const resume = (): void => setPlaying(true);
   const isPlaying = (): boolean => playing;
 
-  playButton.addEventListener('click', togglePlay);
-
-  seek.min = String(start);
-  seek.max = String(end);
-  seek.value = String(start);
-  seek.dispatchEvent(new Event('input'));
+  setSeek(start);
 
   return { togglePlay, pause, resume, stop, isPlaying };
 };


### PR DESCRIPTION
## Summary
- refactor player API to use callbacks instead of DOM refs
- expose play state via hook and simplify PlayButton
- update App to the new player API
- adjust unit tests for refactored player

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e93197538832abcdc005603a7b947