### PR TITLE
Fix Playwright CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-playwright-
       - run: npx playwright install --with-deps
-      - run: npm run test:playwright
       - run: npm run build
+      - run: npm run test:playwright

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npx playwright install
 Run end-to-end tests with:
 
 ```bash
+npm run build
 npm run test:playwright
 ```
 Playwright tests live in the `playwright` directory.

--- a/src/client/lines.tsx
+++ b/src/client/lines.tsx
@@ -304,7 +304,7 @@ export const createFileSimulation = (
           root,
         };
         displayCounts[file.file] = lines;
-        spawnChars(bodies[file.file], file.file, added, removed);
+        spawnChars(bodies[file.file]!, file.file, added, removed);
         if (effectsEnabled) handle.showGlow('glow-new');
       }
     }


### PR DESCRIPTION
## Summary
- ensure that Playwright tests run after building the client
- document build step before Playwright tests
- fix a type error in `lines.tsx`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:playwright`


------
https://chatgpt.com/codex/tasks/task_e_684e9475b1e8832aa00cebee02992e16