### PR TITLE
Refactor player API with callback controls

### DIFF
--- a/src/__tests__/usePlayer.test.ts
+++ b/src/__tests__/usePlayer.test.ts
@@ -10,6 +10,7 @@ describe('usePlayer', () => {
     stop: jest.fn(),
     pause: jest.fn(),
     resume: jest.fn(),
+    togglePlay: jest.fn(),
     isPlaying: jest.fn(() => true),
   };
 
@@ -22,21 +23,17 @@ describe('usePlayer', () => {
   });
 
   it('creates player and exposes controls', () => {
-    const button = document.createElement('button');
-    const seek = document.createElement('input');
-    const duration = document.createElement('input');
-    const buttonRef = { current: button } as React.RefObject<HTMLButtonElement>;
-    const seekRef = { current: seek } as React.RefObject<HTMLInputElement>;
-    const durationRef = { current: duration } as React.RefObject<HTMLInputElement>;
+    const getSeek = jest.fn(() => 0);
+    const setSeek = jest.fn();
 
     const { result } = renderHook(() =>
-      usePlayer(buttonRef, { seekRef, durationRef, start: 0, end: 10 }),
+      usePlayer({ getSeek, setSeek, duration: 1, start: 0, end: 10 }),
     );
 
     expect(createPlayer).toHaveBeenCalledWith({
-      seek,
-      duration,
-      playButton: button,
+      getSeek,
+      setSeek,
+      duration: 1,
       start: 0,
       end: 10,
     });
@@ -45,6 +42,7 @@ describe('usePlayer', () => {
       result.current.pause();
       result.current.resume();
       result.current.stop();
+      result.current.togglePlay();
     });
 
     expect(mockPlayer.pause).toHaveBeenCalled();
@@ -54,15 +52,14 @@ describe('usePlayer', () => {
   });
 
   it('pauses on unmount', () => {
-    const button = document.createElement('button');
-    const seek = document.createElement('input');
-    const duration = document.createElement('input');
-    const buttonRef = { current: button } as React.RefObject<HTMLButtonElement>;
-    const seekRef = { current: seek } as React.RefObject<HTMLInputElement>;
-    const durationRef = { current: duration } as React.RefObject<HTMLInputElement>;
-
     const { unmount } = renderHook(() =>
-      usePlayer(buttonRef, { seekRef, durationRef, start: 0, end: 10 }),
+      usePlayer({
+        getSeek: () => 0,
+        setSeek: () => undefined,
+        duration: 1,
+        start: 0,
+        end: 10,
+      }),
     );
     unmount();
     expect(mockPlayer.pause).toHaveBeenCalled();

--- a/src/client/components/PlayButton.tsx
+++ b/src/client/components/PlayButton.tsx
@@ -1,34 +1,10 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { usePlayer } from '../hooks';
-
-export interface PlayButtonHandle {
-  stop: () => void;
-  pause: () => void;
-  resume: () => void;
-  isPlaying: () => boolean;
-}
+import React from 'react';
 
 export interface PlayButtonProps {
-  seekRef: React.RefObject<HTMLInputElement | null>;
-  durationRef: React.RefObject<HTMLInputElement | null>;
-  start: number;
-  end: number;
-  onPlayStateChange: (playing: boolean) => void;
+  playing: boolean;
+  onToggle: () => void;
 }
 
-export const PlayButton = forwardRef<PlayButtonHandle, PlayButtonProps>(
-  ({ seekRef, durationRef, start, end, onPlayStateChange }, ref) => {
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    const { stop, pause, resume, isPlaying } = usePlayer(buttonRef, {
-      seekRef: seekRef as React.RefObject<HTMLInputElement>,
-      durationRef: durationRef as React.RefObject<HTMLInputElement>,
-      start,
-      end,
-      onPlayStateChange,
-    });
-
-    useImperativeHandle(ref, () => ({ stop, pause, resume, isPlaying }));
-
-    return <button ref={buttonRef}>Play</button>;
-  },
-);
+export function PlayButton({ playing, onToggle }: PlayButtonProps): React.JSX.Element {
+  return <button onClick={onToggle}>{playing ? 'Pause' : 'Play'}</button>;
+}

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -59,37 +59,29 @@ export const useAnimatedSimulation = (
   return { pause, resume, setEffectsEnabled };
 };
 
-export const usePlayer = (
-  buttonRef: React.RefObject<HTMLButtonElement | null>,
-  options: Omit<PlayerOptions, 'playButton' | 'seek' | 'duration'> & {
-    seekRef: React.RefObject<HTMLInputElement | null>;
-    durationRef: React.RefObject<HTMLInputElement | null>;
-  },
-) => {
-  const { seekRef, durationRef, ...opts } = options;
+export const usePlayer = (options: PlayerOptions) => {
+  const { onPlayStateChange, ...opts } = options;
   const playerRef = useRef<ReturnType<typeof createPlayer> | null>(null);
 
   useEffect(() => {
-    if (!buttonRef.current || !seekRef.current || !durationRef.current) return;
     const player = createPlayer({
-      seek: seekRef.current,
-      duration: durationRef.current,
-      playButton: buttonRef.current,
       ...opts,
+      ...(onPlayStateChange ? { onPlayStateChange } : {}),
     });
     playerRef.current = player;
     return () => player.pause();
-  }, [buttonRef, seekRef, durationRef, opts]);
+  }, [opts.getSeek, opts.setSeek, opts.duration, opts.start, opts.end, opts.raf, opts.now, onPlayStateChange]);
 
   const stop = useCallback(() => playerRef.current?.stop(), []);
   const pause = useCallback(() => playerRef.current?.pause(), []);
   const resume = useCallback(() => playerRef.current?.resume(), []);
+  const togglePlay = useCallback(() => playerRef.current?.togglePlay(), []);
   const isPlaying = useCallback(
     () => playerRef.current?.isPlaying() ?? false,
     [],
   );
 
-  return { stop, pause, resume, isPlaying };
+  return { stop, pause, resume, togglePlay, isPlaying };
 };
 
 export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';


### PR DESCRIPTION
## Summary
- update player options to use callbacks instead of DOM refs
- refactor player logic to work with callbacks
- expose player controls via `usePlayer`
- simplify `PlayButton` component
- adapt `App` and tests to the new API

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e95916eac832a86c7097b44335568