### PR TITLE
Add component and hook tests

### DIFF
--- a/src/__tests__/FileCircle.test.tsx
+++ b/src/__tests__/FileCircle.test.tsx
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { FileCircle, type FileCircleHandle } from '../client/components/FileCircle';
+import Matter from 'matter-js';
+
+jest.mock('matter-js', () => ({
+  __esModule: true,
+  default: {
+    Bodies: { circle: jest.fn(() => ({ angle: 0, position: { x: 0, y: 0 } })) },
+    Body: { scale: jest.fn() },
+    Composite: { add: jest.fn(), remove: jest.fn() },
+  },
+}));
+
+const mockMatter = Matter as unknown as {
+  Bodies: { circle: jest.Mock };
+  Body: { scale: jest.Mock };
+  Composite: { add: jest.Mock; remove: jest.Mock };
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('FileCircle', () => {
+  it('forwards methods and updates radius', () => {
+    const engine = { world: {} } as unknown as Matter.Engine;
+    const ref = React.createRef<FileCircleHandle>();
+
+    const { container, unmount } = render(
+      <FileCircle
+        file="a/b.txt"
+        lines={10}
+        initialRadius={10}
+        engine={engine}
+        width={100}
+        height={100}
+        ref={ref}
+      />,
+    );
+
+    expect(mockMatter.Bodies.circle).toHaveBeenCalled();
+    expect(mockMatter.Composite.add).toHaveBeenCalledWith(engine.world, expect.any(Object));
+
+    const circle = container.querySelector('.file-circle') as HTMLDivElement;
+    expect(circle.style.width).toBe('20px');
+
+    act(() => {
+      ref.current?.setCount(5);
+      ref.current?.showGlow('glow', 100);
+      ref.current?.updateRadius(15);
+    });
+
+    expect(circle.querySelector('.count')?.textContent).toBe('5');
+    expect(circle.classList.contains('glow')).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(circle.classList.contains('glow')).toBe(false);
+    expect(mockMatter.Body.scale).toHaveBeenCalledWith(expect.any(Object), 1.5, 1.5);
+    expect(circle.style.width).toBe('30px');
+
+    unmount();
+    expect(mockMatter.Composite.remove).toHaveBeenCalledWith(engine.world, expect.any(Object));
+  });
+});

--- a/src/__tests__/FileCircleContent.test.tsx
+++ b/src/__tests__/FileCircleContent.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import {
+  FileCircleContent,
+  type FileCircleContentHandle,
+} from '../client/components/FileCircleContent';
+
+describe('FileCircleContent', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('exposes DOM and effects', () => {
+    const container = document.createElement('div');
+    const ref = React.createRef<FileCircleContentHandle>();
+    const { getByText } = render(
+      <FileCircleContent
+        path="src/"
+        name="index.ts"
+        count={1}
+        container={{ current: container }}
+        ref={ref}
+      />,
+    );
+
+    expect(ref.current?.charsEl).toBeInstanceOf(HTMLDivElement);
+    expect(getByText('1')).toBeTruthy();
+
+    act(() => {
+      ref.current?.setCount(5);
+      ref.current?.showGlow('glow', 200);
+    });
+
+    expect(getByText('5')).toBeTruthy();
+    expect(container.classList.contains('glow')).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(container.classList.contains('glow')).toBe(false);
+  });
+});

--- a/src/__tests__/SimulationArea.test.tsx
+++ b/src/__tests__/SimulationArea.test.tsx
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { SimulationArea, type SimulationAreaHandle } from '../client/components/SimulationArea';
+import { createFileSimulation } from '../client/lines';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+beforeEach(() => {
+  (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+  jest.clearAllMocks();
+});
+
+describe('SimulationArea', () => {
+  it('initializes simulation and forwards controls', async () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const ref = React.createRef<SimulationAreaHandle>();
+    const data = [{ file: 'a', lines: 1 }];
+    const { container, rerender, unmount } = render(
+      <SimulationArea data={[]} ref={ref} />,
+    );
+    await waitFor(() => expect(createFileSimulation).toHaveBeenCalled());
+    const simEl = container.querySelector('#sim') as HTMLDivElement;
+    expect(createFileSimulation).toHaveBeenCalledWith(simEl);
+    expect(addSpy).toHaveBeenCalledWith('resize', mockSim.resize);
+
+    act(() => {
+      rerender(<SimulationArea data={data} ref={ref} />);
+    });
+    expect(mockSim.update).toHaveBeenCalledWith(data);
+
+    act(() => {
+      ref.current?.pause();
+      ref.current?.resume();
+      ref.current?.setEffectsEnabled(false);
+    });
+    expect(mockSim.pause).toHaveBeenCalled();
+    expect(mockSim.resume).toHaveBeenCalled();
+    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(false);
+
+    unmount();
+    expect(mockSim.destroy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith('resize', mockSim.resize);
+  });
+});

--- a/src/__tests__/useAnimatedSimulation.test.ts
+++ b/src/__tests__/useAnimatedSimulation.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedSimulation } from '../client/hooks';
+import { createFileSimulation } from '../client/lines';
+import type { LineCount } from '../client/types';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+beforeEach(() => {
+  (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+  jest.clearAllMocks();
+});
+
+describe('useAnimatedSimulation', () => {
+  it('updates on data change and forwards controls', () => {
+    const container = document.createElement('div');
+    const ref = { current: container } as React.RefObject<HTMLDivElement>;
+    const { result, rerender, unmount } = renderHook(
+      ({ d }: { d: LineCount[] }) => useAnimatedSimulation(ref, d),
+      { initialProps: { d: [] as LineCount[] } },
+    );
+    expect(createFileSimulation).toHaveBeenCalledWith(container, {});
+
+    act(() => {
+      rerender({ d: [{ file: 'a', lines: 1 }] });
+    });
+    expect(mockSim.update).toHaveBeenCalledWith([{ file: 'a', lines: 1 }]);
+
+    act(() => {
+      result.current.pause();
+      result.current.resume();
+      result.current.setEffectsEnabled(true);
+    });
+    expect(mockSim.pause).toHaveBeenCalled();
+    expect(mockSim.resume).toHaveBeenCalled();
+    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(true);
+
+    unmount();
+    expect(mockSim.destroy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for FileCircle and FileCircleContent components
- test SimulationArea behavior and related hook
- test useAnimatedSimulation hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684e978e84f8832a9e58014421e20e2e