### PR TITLE
Fix Express router integration with Vite

### DIFF
--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,13 +1,16 @@
 import type { Plugin } from 'vite';
 import type { NextHandleFunction } from 'connect';
 import { createApiMiddleware } from './apiMiddleware';
+import express from 'express';
 
 export default function viteExpress(): Plugin {
   return {
     name: 'vite-express',
     async configureServer(server) {
-      const middleware = await createApiMiddleware();
-      server.middlewares.use(middleware as unknown as NextHandleFunction);
+      const router = await createApiMiddleware();
+      const app = express();
+      app.use(router);
+      server.middlewares.use(app as unknown as NextHandleFunction);
     },
   };
 }


### PR DESCRIPTION
## Summary
- wrap the API router with an Express app before registering it in Vite

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684ea345dc78832a8b1b28d2a9b8e721