### PR TITLE
refactor: remove refs from components

### DIFF
--- a/src/__tests__/useFileSimulation.test.ts
+++ b/src/__tests__/useFileSimulation.test.ts
@@ -25,9 +25,8 @@ describe('useFileSimulation', () => {
 
   it('initializes simulation and forwards controls', () => {
     const container = document.createElement('div');
-    const ref = { current: container } as React.RefObject<HTMLDivElement>;
 
-    const { result } = renderHook(() => useFileSimulation(ref));
+    const { result } = renderHook(() => useFileSimulation(container));
 
     expect(createFileSimulation).toHaveBeenCalledWith(container, {});
 
@@ -46,9 +45,8 @@ describe('useFileSimulation', () => {
 
   it('cleans up on unmount', () => {
     const container = document.createElement('div');
-    const ref = { current: container } as React.RefObject<HTMLDivElement>;
 
-    const { unmount } = renderHook(() => useFileSimulation(ref));
+    const { unmount } = renderHook(() => useFileSimulation(container));
     unmount();
 
     expect(mockSim.destroy).toHaveBeenCalled();

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { Commit } from '../types';
 
 export interface CommitLogProps {
@@ -9,8 +9,6 @@ export interface CommitLogProps {
 }
 
 export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 }: CommitLogProps): React.JSX.Element => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
   const [offset, setOffset] = useState(0);
 
   useEffect(() => {
@@ -28,7 +26,7 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
   const end = Math.min(commits.length, index + visible + 1);
   const slice = commits.slice(start, end);
 
-  const containerHeight = containerRef.current?.clientHeight ?? 1;
+  const containerHeight = document.getElementById('commit-log')?.clientHeight ?? 1;
   const spanMs =
     slice.length > 1
       ?
@@ -39,8 +37,8 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
   const msPerPx = spanMs / Math.max(containerHeight, 1);
 
   useEffect(() => {
-    const list = listRef.current;
-    const container = containerRef.current;
+    const container = document.getElementById('commit-log');
+    const list = container?.querySelector<HTMLUListElement>('ul.commit-list');
     if (!list || !container) return;
     const current = list.querySelector<HTMLLIElement>('li.current');
     if (!current) return;
@@ -62,12 +60,8 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
   }, [slice, timestamp, index, commits]);
 
   return (
-    <div id="commit-log" ref={containerRef}>
-      <ul
-        className="commit-list"
-        ref={listRef}
-        style={{ transform: `translateY(${offset}px)` }}
-      >
+    <div id="commit-log">
+      <ul className="commit-list" style={{ transform: `translateY(${offset}px)` }}>
         {slice.map((c, i) => {
           const diff =
             i > 0

--- a/src/client/components/DurationInput.tsx
+++ b/src/client/components/DurationInput.tsx
@@ -5,16 +5,19 @@ export interface DurationInputProps {
   onInput?: (value: number) => void;
 }
 
-export const DurationInput = React.forwardRef<HTMLInputElement, DurationInputProps>(
-  ({ defaultValue = 20, onInput }, ref) => (
+export function DurationInput({
+  defaultValue = 20,
+  onInput,
+}: DurationInputProps): React.JSX.Element {
+  return (
     <input
       type="number"
-      ref={ref}
       defaultValue={defaultValue}
       min={1}
       onInput={
         onInput ? (e) => onInput(Number((e.target as HTMLInputElement).value)) : undefined
       }
     />
-  ),
-);
+  );
+}
+

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -1,15 +1,6 @@
-import React, {
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useState,
-  useEffect,
-} from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import Matter from 'matter-js';
-import {
-  FileCircleContent,
-  type FileCircleContentHandle,
-} from './FileCircleContent';
+import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
 import { colorForFile } from '../lines';
 
 const { Bodies, Body, Composite } = Matter;
@@ -27,80 +18,82 @@ interface FileCircleProps {
   engine: Matter.Engine;
   width: number;
   height: number;
+  onReady?: (handle: FileCircleHandle) => void;
 }
 
-export const FileCircle = forwardRef<FileCircleHandle, FileCircleProps>(
-  (
-    { file, lines, initialRadius, engine, width, height },
-    ref,
-  ) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const contentRef = useRef<FileCircleContentHandle>(null);
-    const [radius, setRadius] = useState(initialRadius);
-    const [body] = useState(() =>
-      Bodies.circle(
-        Math.random() * (width - 2 * initialRadius) + initialRadius,
-        -Math.random() * height - initialRadius,
-        initialRadius,
-        { restitution: 0.9, frictionAir: 0.01 },
-      ),
-    );
+export function FileCircle({
+  file,
+  lines,
+  initialRadius,
+  engine,
+  width,
+  height,
+  onReady,
+}: FileCircleProps): React.JSX.Element {
+  const containerId = useId();
+  const [contentHandle, setContentHandle] = useState<FileCircleContentHandle | null>(null);
+  const [radius, setRadius] = useState(initialRadius);
+  const [body] = useState(() =>
+    Bodies.circle(
+      Math.random() * (width - 2 * initialRadius) + initialRadius,
+      -Math.random() * height - initialRadius,
+      initialRadius,
+      { restitution: 0.9, frictionAir: 0.01 },
+    ),
+  );
 
-    useEffect(() => {
-      Composite.add(engine.world, body);
-      return () => {
-        Composite.remove(engine.world, body);
-      };
-    }, [engine, body]);
-
-    const updateRadius = (r: number): void => {
-      if (r === radius) return;
-      Body.scale(body, r / radius, r / radius);
-      setRadius(r);
-      const el = containerRef.current;
-      if (el) {
-        el.style.width = `${r * 2}px`;
-        el.style.height = `${r * 2}px`;
-      }
+  useEffect(() => {
+    Composite.add(engine.world, body);
+    return () => {
+      Composite.remove(engine.world, body);
     };
+  }, [engine, body]);
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        body,
-        radius,
-        updateRadius,
-        charsEl: contentRef.current?.charsEl ?? null,
-        setCount: contentRef.current?.setCount ?? (() => {}),
-        showGlow: contentRef.current?.showGlow ?? (() => {}),
-      }),
-      [body, radius],
-    );
+  const updateRadius = (r: number): void => {
+    if (r === radius) return;
+    Body.scale(body, r / radius, r / radius);
+    setRadius(r);
+    const el = document.getElementById(containerId);
+    if (el) {
+      el.style.width = `${r * 2}px`;
+      el.style.height = `${r * 2}px`;
+    }
+  };
 
-    const dir = file.split('/');
-    const name = dir.pop() ?? '';
+  useEffect(() => {
+    if (!contentHandle) return;
+    onReady?.({
+      body,
+      radius,
+      updateRadius,
+      ...contentHandle,
+    });
+  }, [contentHandle, onReady, body, radius]);
 
-    return (
-      <div
-        className="file-circle"
-        ref={containerRef}
-        style={{
-          position: 'absolute',
-          width: `${radius * 2}px`,
-          height: `${radius * 2}px`,
-          borderRadius: '50%',
-          background: colorForFile(file),
-          willChange: 'transform',
-        }}
-      >
-        <FileCircleContent
-          path={dir.join('/') + (dir.length ? '/' : '')}
-          name={name}
-          count={lines}
-          container={containerRef}
-          ref={contentRef}
-        />
-      </div>
-    );
-  },
-);
+  const dir = file.split('/');
+  const name = dir.pop() ?? '';
+
+  return (
+    <div
+      className="file-circle"
+      id={containerId}
+      style={{
+        position: 'absolute',
+        width: `${radius * 2}px`,
+        height: `${radius * 2}px`,
+        borderRadius: '50%',
+        background: colorForFile(file),
+        willChange: 'transform',
+      }}
+    >
+      <FileCircleContent
+        path={dir.join('/') + (dir.length ? '/' : '')}
+        name={name}
+        count={lines}
+        containerId={containerId}
+        onReady={setContentHandle}
+      />
+    </div>
+  );
+}
+

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,9 +1,4 @@
-import React, {
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useId, useState } from 'react';
 
 export interface FileCircleContentHandle {
   charsEl: HTMLDivElement | null;
@@ -15,38 +10,44 @@ export interface FileCircleContentProps {
   path: string;
   name: string;
   count: number;
-  container: React.RefObject<HTMLDivElement | null>;
+  containerId: string;
+  onReady?: (handle: FileCircleContentHandle) => void;
 }
 
-export const FileCircleContent = forwardRef<
-  FileCircleContentHandle,
-  FileCircleContentProps
->(({ path, name, count, container }, ref) => {
+export function FileCircleContent({
+  path,
+  name,
+  count,
+  containerId,
+  onReady,
+}: FileCircleContentProps): React.JSX.Element {
   const [currentCount, setCurrentCount] = useState(count);
-  const charsRef = useRef<HTMLDivElement>(null);
+  const charsId = useId();
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      charsEl: charsRef.current,
+  useEffect(() => {
+    const charsEl = document.getElementById(charsId) as HTMLDivElement | null;
+    const container = document.getElementById(containerId) as HTMLDivElement | null;
+    if (!onReady) return;
+    const handle: FileCircleContentHandle = {
+      charsEl,
       setCount: setCurrentCount,
       showGlow: (cls: string, ms = 500) => {
-        const el = container.current;
-        if (!el) return;
-        el.classList.add(cls);
-        setTimeout(() => el.classList.remove(cls), ms);
+        if (!container) return;
+        container.classList.add(cls);
+        setTimeout(() => container.classList.remove(cls), ms);
       },
-    }),
-    [container],
-  );
+    };
+    onReady(handle);
+  }, [charsId, containerId, onReady]);
 
   return (
     <>
       <div className="path">{path}</div>
       <div className="name">{name}</div>
       <div className="count">{currentCount}</div>
-      <div className="chars" ref={charsRef} />
+      <div className="chars" id={charsId} />
     </>
   );
-});
+}
+
 

--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,9 +1,4 @@
-import React, {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-} from 'react';
+import React, { useEffect, useState } from 'react';
 import { createFileSimulation } from '../lines';
 import type { LineCount } from '../types';
 
@@ -15,35 +10,33 @@ export interface SimulationAreaHandle {
 
 interface SimulationAreaProps {
   data: LineCount[];
+  onReady?: (handle: SimulationAreaHandle) => void;
 }
 
-export const SimulationArea = forwardRef<SimulationAreaHandle, SimulationAreaProps>(
-  ({ data }, ref) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const simRef = useRef<ReturnType<typeof createFileSimulation> | null>(null);
+export function SimulationArea({ data, onReady }: SimulationAreaProps): React.JSX.Element {
+  const [sim, setSim] = useState<ReturnType<typeof createFileSimulation> | null>(null);
 
-    useEffect(() => {
-      if (!containerRef.current) return;
-      const sim = createFileSimulation(containerRef.current);
-      simRef.current = sim;
-      window.addEventListener('resize', sim.resize);
-      return () => {
-        window.removeEventListener('resize', sim.resize);
-        sim.destroy();
-      };
-    }, []);
+  useEffect(() => {
+    const el = document.getElementById('sim');
+    if (!el) return;
+    const instance = createFileSimulation(el);
+    setSim(instance);
+    onReady?.({
+      pause: instance.pause,
+      resume: instance.resume,
+      setEffectsEnabled: instance.setEffectsEnabled,
+    });
+    window.addEventListener('resize', instance.resize);
+    return () => {
+      window.removeEventListener('resize', instance.resize);
+      instance.destroy();
+    };
+  }, [onReady]);
 
-    useEffect(() => {
-      if (data.length) simRef.current?.update(data);
-    }, [data]);
+  useEffect(() => {
+    if (data.length && sim) sim.update(data);
+  }, [data, sim]);
 
-    const pause = (): void => simRef.current?.pause();
-    const resume = (): void => simRef.current?.resume();
-    const setEffectsEnabled = (state: boolean): void =>
-      simRef.current?.setEffectsEnabled(state);
+  return <div id="sim" />;
+}
 
-    useImperativeHandle(ref, () => ({ pause, resume, setEffectsEnabled }));
-
-    return <div id="sim" ref={containerRef} />;
-  },
-);


### PR DESCRIPTION
## Summary
- remove React refs across client components
- refactor hooks to rely on state and callbacks
- adjust simulation logic for callback-based handles
- update related tests

## Testing
- `npm run lint`
- `npm test -- -w=1` *(fails: lines.test.ts not passing; Jest runs out of memory)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ea3eedde0832aade0af620e052000