### PR TITLE
Add global Jest timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ export default {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+  testTimeout: 10000,
   collectCoverage: true,
   collectCoverageFrom: [
     'src/math.ts',


### PR DESCRIPTION
## Summary
- add `testTimeout` in `jest.config.js`

## Testing
- `npm run lint` *(fails: max warnings 0)*
- `npm test` *(fails: coverage threshold & OOM)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ea90460bc832aa27e9c3a434adf02