### PR TITLE
fix(tests): remove unnecessary lint suppressions

### DIFF
--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -21,8 +21,15 @@ describe('App commit log', () => {
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
         return Promise.resolve({ json: () => Promise.resolve([]) });
       }
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      return Promise.reject(new Error(`Unexpected url: ${String(input)}`));
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
     }) as jest.Mock;
   });
 

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -18,8 +18,15 @@ describe('client index', () => {
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
         return Promise.resolve({ json: () => Promise.resolve([]) });
       }
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      return Promise.reject(new Error(`Unexpected url: ${String(input)}`));
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
     }) as jest.Mock;
   });
 


### PR DESCRIPTION
## Summary
- remove `@typescript-eslint/no-base-to-string` overrides in tests
- derive URL strings safely

## Testing
- `npm run lint`
- `npm test` *(fails: "global" coverage threshold for lines not met)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684eb1c4fb68832a895c37209b6847d1