### PR TITLE
add file simulation hook

### DIFF
--- a/src/__tests__/SimulationArea.test.tsx
+++ b/src/__tests__/SimulationArea.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { SimulationArea } from '../client/components/SimulationArea';
+import { useFileSimulationRef } from '../client/hooks';
+import type { LineCount } from '../client/types';
+
+jest.mock('../client/hooks');
+
+const update = jest.fn();
+const pause = jest.fn();
+const resume = jest.fn();
+const setEffectsEnabled = jest.fn();
+const ref = jest.fn();
+
+(useFileSimulationRef as jest.Mock).mockReturnValue({
+  ref,
+  update,
+  pause,
+  resume,
+  setEffectsEnabled,
+});
+
+const data: LineCount[] = [{ file: 'a', lines: 1 }];
+
+describe('SimulationArea', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFileSimulationRef as jest.Mock).mockReturnValue({
+      ref,
+      update,
+      pause,
+      resume,
+      setEffectsEnabled,
+    });
+  });
+
+  it('forwards handle via onReady', () => {
+    const onReady = jest.fn();
+    render(<SimulationArea data={[]} onReady={onReady} />);
+    expect(onReady).toHaveBeenCalledWith({ pause, resume, setEffectsEnabled });
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+
+  it('updates simulation on data change', () => {
+    const { rerender } = render(<SimulationArea data={[]} />);
+    act(() => {
+      rerender(<SimulationArea data={data} />);
+    });
+    expect(update).toHaveBeenCalledWith(data);
+  });
+});

--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { createFileSimulation } from '../lines';
+import React, { useEffect } from 'react';
+import { useFileSimulationRef } from '../hooks';
 import type { LineCount } from '../types';
 
 export interface SimulationAreaHandle {
@@ -14,29 +14,16 @@ interface SimulationAreaProps {
 }
 
 export function SimulationArea({ data, onReady }: SimulationAreaProps): React.JSX.Element {
-  const [sim, setSim] = useState<ReturnType<typeof createFileSimulation> | null>(null);
+  const { ref, update, pause, resume, setEffectsEnabled } = useFileSimulationRef();
 
   useEffect(() => {
-    const el = document.getElementById('sim');
-    if (!el) return;
-    const instance = createFileSimulation(el);
-    setSim(instance);
-    onReady?.({
-      pause: instance.pause,
-      resume: instance.resume,
-      setEffectsEnabled: instance.setEffectsEnabled,
-    });
-    window.addEventListener('resize', instance.resize);
-    return () => {
-      window.removeEventListener('resize', instance.resize);
-      instance.destroy();
-    };
-  }, [onReady]);
+    onReady?.({ pause, resume, setEffectsEnabled });
+  }, [onReady, pause, resume, setEffectsEnabled]);
 
   useEffect(() => {
-    if (data.length && sim) sim.update(data);
-  }, [data, sim]);
+    if (data.length) update(data);
+  }, [data, update]);
 
-  return <div id="sim" />;
+  return <div id="sim" ref={ref} />;
 }
 

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -38,6 +38,21 @@ export const useFileSimulation = (
   return { update, pause, resume, setEffectsEnabled };
 };
 
+export const useFileSimulationRef = (
+  opts: {
+    raf?: (cb: FrameRequestCallback) => number;
+    now?: () => number;
+    linear?: boolean;
+  } = {},
+) => {
+  const [el, setEl] = useState<HTMLElement | null>(null);
+  const ref = useCallback((node: HTMLElement | null) => setEl(node), []);
+
+  const controls = useFileSimulation(el, opts);
+
+  return { ref, ...controls };
+};
+
 export const useAnimatedSimulation = (
   container: HTMLElement | null,
   data: LineCount[],


### PR DESCRIPTION
## Summary
- add `useFileSimulationRef` to return a ref for the simulation container
- refactor `SimulationArea` to use the new hook
- test the ref-based simulation hook usage

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684eb735c36c832a916a5fa17457e268