### PR TITLE
Remove lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,16 +25,7 @@ const eslintrc = {
     semi: ['error', 'always'],
     quotes: ['error', 'single'],
     '@typescript-eslint/no-unused-vars': ['error'],
-    // TODO: change to 'error' after resolving legacy issues
-    'react/display-name': 'warn',
-    // TODO: change to 'error' after resolving legacy issues
-    'react/jsx-uses-react': 'warn',
-    // TODO: change to 'error' after resolving legacy issues
-    'react/react-in-jsx-scope': 'warn',
-    // TODO: change to 'error' after verifying hook usage
-    'react-hooks/rules-of-hooks': 'warn',
-    // TODO: change to 'error' after verifying dependencies
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
     'no-restricted-syntax': [
       'error',
       {


### PR DESCRIPTION
## Summary
- drop legacy ESLint overrides and enable `react-hooks/exhaustive-deps`

## Testing
- `npm run lint` *(fails: useRef is prohibited)*
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684eb9175a38832aa60766a5f68c8ce6