### PR TITLE
Add tests for simulation hooks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,9 +16,8 @@ export default {
     'src/client/**/*.{ts,tsx}',
   ],
   coverageThreshold: {
-    // TODO: increase to 80 once additional tests are added
     global: {
-      lines: 75,
+      lines: 80,
     },
   },
 };

--- a/src/__tests__/useAnimatedSimulation.test.ts
+++ b/src/__tests__/useAnimatedSimulation.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedSimulation } from '../client/hooks';
+import { createFileSimulation } from '../client/lines';
+import type { LineCount } from '../client/types';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+describe('useAnimatedSimulation', () => {
+  beforeEach(() => {
+    (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates simulation when data changes and forwards controls', () => {
+    const container = document.createElement('div');
+    let lines: LineCount[] = [];
+
+    const { result, rerender } = renderHook(
+      ({ data }) => useAnimatedSimulation(container, data),
+      { initialProps: { data: lines } },
+    );
+
+    expect(createFileSimulation).toHaveBeenCalledWith(container, {});
+    expect(mockSim.update).not.toHaveBeenCalled();
+
+    lines = [{ file: 'f', lines: 1 }];
+    rerender({ data: lines });
+
+    expect(mockSim.update).toHaveBeenCalledWith(lines);
+
+    act(() => {
+      result.current.pause();
+      result.current.resume();
+      result.current.setEffectsEnabled(false);
+    });
+
+    expect(mockSim.pause).toHaveBeenCalled();
+    expect(mockSim.resume).toHaveBeenCalled();
+    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('destroys simulation on unmount', () => {
+    const container = document.createElement('div');
+    const { unmount } = renderHook(() =>
+      useAnimatedSimulation(container, [{ file: 'a', lines: 1 }]),
+    );
+
+    unmount();
+    expect(mockSim.destroy).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/useFileSimulationRef.test.ts
+++ b/src/__tests__/useFileSimulationRef.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useFileSimulationRef } from '../client/hooks';
+import { createFileSimulation } from '../client/lines';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+describe('useFileSimulationRef', () => {
+  beforeEach(() => {
+    (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes simulation when ref assigned and forwards controls', () => {
+    const { result } = renderHook(() => useFileSimulationRef());
+    const el = document.createElement('div');
+
+    act(() => {
+      result.current.ref(el);
+    });
+
+    expect(createFileSimulation).toHaveBeenCalledWith(el, {});
+
+    act(() => {
+      result.current.update([]);
+      result.current.pause();
+      result.current.resume();
+      result.current.setEffectsEnabled(true);
+    });
+
+    expect(mockSim.update).toHaveBeenCalledWith([]);
+    expect(mockSim.pause).toHaveBeenCalled();
+    expect(mockSim.resume).toHaveBeenCalled();
+    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('cleans up on unmount', () => {
+    const { result, unmount } = renderHook(() => useFileSimulationRef());
+    const el = document.createElement('div');
+    act(() => result.current.ref(el));
+
+    unmount();
+
+    expect(mockSim.destroy).toHaveBeenCalled();
+  });
+});

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -59,7 +59,7 @@ export function FileCircleContent({
       },
     };
     onReady(handle);
-  }, [onReady, nextId]);
+  }, [onReady]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- add coverage for `useFileSimulationRef`
- add coverage for `useAnimatedSimulation`
- remove stray dependency from `FileCircleContent`
- raise jest coverage threshold to 80%

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684ebb5b34b0832aa49641a8039b76ba