### PR TITLE
Remove redundant DOM append in lines tests

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -19,7 +19,6 @@ describe('lines module', () => {
   it('renders circles', async () => {
     const div = document.createElement('div');
     document.body.appendChild(div);
-    document.body.appendChild(div);
     div.getBoundingClientRect = () => ({
       width: 200,
       height: 200,


### PR DESCRIPTION
## Summary
- clean up DOM setup in lines test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684ec02c1d50832a9a657ed843bcf0b4