### PR TITLE
Add option tests for simulation and player hooks

### DIFF
--- a/src/__tests__/useFileSimulation.options.test.ts
+++ b/src/__tests__/useFileSimulation.options.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import { useFileSimulation } from '../client/hooks';
+import { createFileSimulation } from '../client/lines';
+
+jest.mock('../client/lines');
+
+const mockSim = {
+  update: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  resize: jest.fn(),
+  destroy: jest.fn(),
+  setEffectsEnabled: jest.fn(),
+};
+
+beforeEach(() => {
+  (createFileSimulation as jest.Mock).mockReturnValue({ ...mockSim });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useFileSimulation options', () => {
+  it('ignores null container', () => {
+    renderHook(() => useFileSimulation(null));
+    expect(createFileSimulation).not.toHaveBeenCalled();
+  });
+
+  it('passes options and handles resize', () => {
+    const container = document.createElement('div');
+    const options = { raf: jest.fn(), now: jest.fn(), linear: true };
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useFileSimulation(container, options));
+
+    expect(createFileSimulation).toHaveBeenCalledWith(container, options);
+    expect(addSpy).toHaveBeenCalledWith('resize', mockSim.resize);
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('resize', mockSim.resize);
+  });
+});

--- a/src/__tests__/usePlayer.options.test.ts
+++ b/src/__tests__/usePlayer.options.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import { usePlayer } from '../client/hooks';
+import { createPlayer } from '../client/player';
+
+jest.mock('../client/player');
+
+describe('usePlayer options', () => {
+  const mockPlayer = {
+    stop: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    togglePlay: jest.fn(),
+    isPlaying: jest.fn(() => false),
+  };
+
+  beforeEach(() => {
+    (createPlayer as jest.Mock).mockImplementation((opts: Record<string, unknown>) => {
+      const cb = opts.onPlayStateChange as ((p: boolean) => void) | undefined;
+      cb?.(true);
+      return mockPlayer;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards raf and now and play state callback', () => {
+    const raf = jest.fn();
+    const now = jest.fn();
+    const onPlayStateChange = jest.fn();
+
+    renderHook(() =>
+      usePlayer({
+        getSeek: () => 0,
+        setSeek: () => undefined,
+        duration: 1,
+        start: 0,
+        end: 2,
+        raf,
+        now,
+        onPlayStateChange,
+      }),
+    );
+
+    const call = (createPlayer as jest.Mock).mock.calls[0] as [
+      {
+        raf?: unknown;
+        now?: unknown;
+        onPlayStateChange?: unknown;
+      },
+    ];
+    const args = call[0];
+    expect(args.raf).toBe(raf);
+    expect(args.now).toBe(now);
+    expect(typeof args.onPlayStateChange).toBe('function');
+    expect(onPlayStateChange).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for useFileSimulation options & null container
- test usePlayer option forwarding and play state callback

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684ec04efcb4832a96834c049e9675ac