### PR TITLE
feat: hide matter-js via hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,5 @@
 - Investigate any `deprecated` warnings from package installs.
 - Make these checks part of the regular workflow and account for them when updating CI.
 * TODO: add more hook tests and restore coverage threshold to 80.
+* Use React refs only when absolutely necessary and preferably within custom hooks.
+  Override the ESLint ref restriction locally in such files or lines.

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useId, useState, useCallback } from 'react';
-import Matter from 'matter-js';
+import { useMatter } from '../hooks';
+import type Matter from 'matter-js';
 import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
 import { colorForFile } from '../lines';
-
-const { Bodies, Body, Composite } = Matter;
 
 export interface FileCircleHandle extends FileCircleContentHandle {
   body: Matter.Body;
@@ -32,6 +31,8 @@ export function FileCircle({
   height,
   onReady,
 }: FileCircleProps): React.JSX.Element {
+  const Matter = useMatter();
+  const { Bodies, Body, Composite } = Matter;
   const containerId = useId();
   const [contentHandle, setContentHandle] = useState<FileCircleContentHandle | null>(null);
   const [radius, setRadius] = useState(initialRadius);
@@ -51,7 +52,7 @@ export function FileCircle({
     return () => {
       Composite.remove(engine.world, body);
     };
-  }, [engine, body]);
+  }, [engine, body, Composite]);
 
   const updateRadius = useCallback((r: number): void => {
     if (r === radius) return;
@@ -62,7 +63,7 @@ export function FileCircle({
       el.style.width = `${r * 2}px`;
       el.style.height = `${r * 2}px`;
     }
-  }, [radius, body, containerId]);
+  }, [radius, body, containerId, Body]);
 
   const showGlow = useCallback((cls: string, ms = 500): void => {
     setGlow(cls);

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -121,3 +121,4 @@ export const usePlayer = (options: PlayerOptions) => {
 
 export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';
 export { usePageVisibility } from './usePageVisibility';
+export { useMatter } from './useMatter';

--- a/src/client/hooks/useMatter.ts
+++ b/src/client/hooks/useMatter.ts
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+import Matter from 'matter-js';
+
+/**
+ * Provides the Matter.js API through a hook so components don't
+ * import the library directly.
+ */
+export const useMatter = () => useMemo(() => Matter, []);


### PR DESCRIPTION
## Summary
- encapsulate matter-js access in `useMatter`
- use `useMatter` in `FileCircle`
- export the new hook
- document careful ref usage

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`

------
https://chatgpt.com/codex/tasks/task_e_684ec280c6d0832aaace40cbd936d75f