### PR TITLE
codex/glow-animation-hook

### DIFF
--- a/src/__tests__/useGlowAnimation.test.ts
+++ b/src/__tests__/useGlowAnimation.test.ts
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useGlowAnimation } from '../client/hooks/useGlowAnimation';
+
+describe('useGlowAnimation', () => {
+  it('starts and clears class', () => {
+    const { result } = renderHook(() => useGlowAnimation());
+
+    act(() => {
+      result.current[0]('glow');
+    });
+    expect(result.current[1].className).toBe('glow');
+
+    act(() => {
+      result.current[1].onAnimationEnd();
+    });
+    expect(result.current[1].className).toBe('');
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useId, useState, useCallback } from 'react';
 import Matter from 'matter-js';
 import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
 import { colorForFile } from '../lines';
+import { useGlowAnimation } from '../hooks';
 
 const { Bodies, Body, Composite } = Matter;
 
@@ -9,7 +10,7 @@ export interface FileCircleHandle extends FileCircleContentHandle {
   body: Matter.Body;
   radius: number;
   updateRadius: (r: number) => void;
-  showGlow: (cls: string, ms?: number) => void;
+  showGlow: (cls: string) => void;
   hide: () => void;
 }
 
@@ -35,7 +36,7 @@ export function FileCircle({
   const containerId = useId();
   const [contentHandle, setContentHandle] = useState<FileCircleContentHandle | null>(null);
   const [radius, setRadius] = useState(initialRadius);
-  const [glow, setGlow] = useState('');
+  const [startGlow, glowProps] = useGlowAnimation();
   const [hidden, setHidden] = useState(false);
   const [body] = useState(() =>
     Bodies.circle(
@@ -64,10 +65,12 @@ export function FileCircle({
     }
   }, [radius, body, containerId]);
 
-  const showGlow = useCallback((cls: string, ms = 500): void => {
-    setGlow(cls);
-    setTimeout(() => setGlow(''), ms);
-  }, []);
+  const showGlow = useCallback(
+    (cls: string): void => {
+      startGlow(cls);
+    },
+    [startGlow],
+  );
 
   const hide = useCallback((): void => {
     setHidden(true);
@@ -90,8 +93,9 @@ export function FileCircle({
 
   return (
     <div
-      className={`file-circle ${glow}`}
+      className={`file-circle ${glowProps.className}`}
       id={containerId}
+      onAnimationEnd={glowProps.onAnimationEnd}
       style={{
         position: 'absolute',
         width: `${radius * 2}px`,

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -125,4 +125,5 @@ export const usePlayer = (options: PlayerOptions) => {
 };
 
 export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';
+export { useGlowAnimation } from './useGlowAnimation';
 export { usePageVisibility } from './usePageVisibility';

--- a/src/client/hooks/useGlowAnimation.ts
+++ b/src/client/hooks/useGlowAnimation.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState, type DependencyList } from 'react';
+import type { AnimationProps } from './useCssAnimation';
+
+export type UseGlowAnimationResult = [(cls: string) => void, AnimationProps];
+
+export const useGlowAnimation = (
+  deps: DependencyList = [],
+): UseGlowAnimationResult => {
+  const [glow, setGlow] = useState('');
+
+  /* eslint-disable react-hooks/exhaustive-deps */
+  const start = useCallback((cls: string) => {
+    setGlow(cls);
+  }, deps);
+
+  const onAnimationEnd = useCallback(() => {
+    setGlow('');
+  }, deps);
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  return [start, { className: glow, onAnimationEnd }];
+};


### PR DESCRIPTION
## Summary
- add `useGlowAnimation` hook to manage transient css classes
- integrate glow hook with `FileCircle` component
- export new hook from hooks index
- test glow animation hook

## Testing
- `npx playwright install`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ec2b6cf3c832a82c347b8f5765e9d