### PR TITLE
fix seekbar range

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -78,7 +78,12 @@ export function App(): React.JSX.Element {
         <div id="controls">
           <PlayButton playing={player.isPlaying()} onToggle={player.togglePlay} />
           <button onClick={player.stop}>Stop</button>
-          <SeekBar value={timestamp} onInput={setTimestamp} />
+          <SeekBar
+            value={timestamp}
+            min={start}
+            max={end}
+            onInput={setTimestamp}
+          />
           <DurationInput defaultValue={duration} onInput={setDuration} />s
         </div>
       )}

--- a/src/client/components/SeekBar.tsx
+++ b/src/client/components/SeekBar.tsx
@@ -2,14 +2,18 @@ import React from 'react';
 
 export interface SeekBarProps {
   value: number;
+  min: number;
+  max: number;
   onInput: (value: number) => void;
 }
 
-export function SeekBar({ value, onInput }: SeekBarProps): React.JSX.Element {
+export function SeekBar({ value, min, max, onInput }: SeekBarProps): React.JSX.Element {
   return (
     <input
       type="range"
       value={value}
+      min={min}
+      max={max}
       onInput={(e) => onInput(Number((e.target as HTMLInputElement).value))}
     />
   );


### PR DESCRIPTION
## Summary
- pass start/end bounds to the React seek bar
- connect timestamp range to the slider

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_684ec4f4e82c832ab1c2374722bcb47d