### PR TITLE
Add engine context and body hook

### DIFF
--- a/src/__tests__/useBody.test.tsx
+++ b/src/__tests__/useBody.test.tsx
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { PhysicsProvider, useEngine, useBody } from '../client/hooks';
+
+describe('useBody', () => {
+  it('adds body to engine and supports size updates', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+    );
+
+    const { result, unmount } = renderHook(() => {
+      const engine = useEngine();
+      const info = useBody({ radius: 10 });
+      return { engine, ...info };
+    }, { wrapper });
+
+    expect(result.current.engine.world.bodies).toContain(result.current.body);
+
+    act(() => {
+      result.current.setRadius(20);
+    });
+    expect(result.current.body.radius).toBe(20);
+
+    unmount();
+    expect(result.current.engine.world.bodies).not.toContain(result.current.body);
+  });
+});

--- a/src/__tests__/useEngine.test.tsx
+++ b/src/__tests__/useEngine.test.tsx
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { PhysicsProvider, useEngine } from '../client/hooks';
+
+describe('PhysicsProvider', () => {
+  it('updates engine bounds', () => {
+    let width = 50;
+    let height = 60;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PhysicsProvider bounds={{ width, height }}>{children}</PhysicsProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useEngine(), { wrapper });
+
+    expect(result.current.bounds).toEqual({ width: 50, height: 60 });
+
+    width = 80;
+    height = 90;
+    rerender();
+
+    expect(result.current.bounds).toEqual({ width: 80, height: 90 });
+  });
+});

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -128,3 +128,5 @@ export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';
 export { useGlowAnimation } from './useGlowAnimation';
 export { usePageVisibility } from './usePageVisibility';
 export { usePhysics } from './usePhysics';
+export { PhysicsProvider, useEngine } from './useEngine';
+export { useBody } from './useBody';

--- a/src/client/hooks/useBody.ts
+++ b/src/client/hooks/useBody.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import * as Physics from '../physics';
+import { useEngine } from './useEngine';
+
+interface BodyOptions {
+  radius: number;
+  restitution?: number;
+  frictionAir?: number;
+}
+
+export const useBody = (options: BodyOptions) => {
+  const engine = useEngine();
+  const { radius, restitution = 0, frictionAir = 0 } = options;
+
+  const [body] = useState(() =>
+    Physics.Bodies.circle(
+      Math.random() * (engine.bounds.width - radius * 2) + radius,
+      -radius,
+      radius,
+      { restitution, frictionAir },
+    ),
+  );
+
+  useEffect(() => {
+    Physics.Composite.add(engine.world, body);
+    return () => {
+      Physics.Composite.remove(engine.world, body);
+    };
+  }, [engine, body]);
+
+  const setRadius = useCallback(
+    (r: number) => {
+      if (body.radius === undefined || body.radius === r) return;
+      Physics.Body.scale(body, r / body.radius, r / body.radius);
+    },
+    [body],
+  );
+
+  return { body, setRadius } as const;
+};

--- a/src/client/hooks/useEngine.tsx
+++ b/src/client/hooks/useEngine.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import * as Physics from '../physics';
+
+interface Bounds {
+  width: number;
+  height: number;
+}
+
+const EngineContext = createContext<Physics.Engine | null>(null);
+
+interface PhysicsProviderProps {
+  bounds: Bounds;
+  children: React.ReactNode;
+}
+
+export function PhysicsProvider({ bounds, children }: PhysicsProviderProps): React.JSX.Element {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const engine = useMemo(() => Physics.Engine.create(bounds.width, bounds.height), []);
+
+  useEffect(() => {
+    engine.bounds.width = bounds.width;
+    engine.bounds.height = bounds.height;
+  }, [engine, bounds.width, bounds.height]);
+
+  return <EngineContext.Provider value={engine}>{children}</EngineContext.Provider>;
+}
+
+export const useEngine = (): Physics.Engine => {
+  const engine = useContext(EngineContext);
+  if (!engine) throw new Error('useEngine must be used within PhysicsProvider');
+  return engine;
+};


### PR DESCRIPTION
## Summary
- add `PhysicsProvider` and `useEngine` hooks
- add `useBody` hook for circle bodies
- export new hooks
- test `PhysicsProvider` and `useBody`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ece78e824832aaa08a36bf58f1d68