### PR TITLE
Use body transform state in FileCircle

### DIFF
--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -53,7 +53,6 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
       Object.values(handles.current).forEach((h) => {
         const { x, y } = h.body.position;
         const r = h.radius;
-        h.el.style.transform = `translate3d(${x - r}px, ${y - r}px, 0) rotate(${h.body.angle}rad)`;
         if (
           x < -r ||
           x > bounds.width + r ||
@@ -101,9 +100,6 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
             file={d.file}
             lines={d.lines}
             initialRadius={r}
-            engine={engine}
-            width={bounds.width}
-            height={bounds.height}
             onReady={(h) => {
               handles.current[d.file] = h;
             }}

--- a/src/client/hooks/useEngine.tsx
+++ b/src/client/hooks/useEngine.tsx
@@ -10,12 +10,15 @@ const EngineContext = createContext<Physics.Engine | null>(null);
 
 interface PhysicsProviderProps {
   bounds: Bounds;
+  engine?: Physics.Engine;
   children: React.ReactNode;
 }
 
-export function PhysicsProvider({ bounds, children }: PhysicsProviderProps): React.JSX.Element {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const engine = useMemo(() => Physics.Engine.create(bounds.width, bounds.height), []);
+export function PhysicsProvider({ bounds, engine: externalEngine, children }: PhysicsProviderProps): React.JSX.Element {
+  const engine = useMemo(
+    () => externalEngine ?? Physics.Engine.create(bounds.width, bounds.height),
+    [externalEngine, bounds.width, bounds.height],
+  );
 
   useEffect(() => {
     engine.bounds.width = bounds.width;

--- a/src/client/lines.tsx
+++ b/src/client/lines.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { createPortal, flushSync } from 'react-dom';
 import { FileCircle, type FileCircleHandle } from './components/FileCircle';
+import { PhysicsProvider } from './hooks';
 import * as Physics from './physics';
 const { Body, Composite, Engine } = Physics;
 
@@ -132,9 +133,6 @@ export const createFileSimulation = (
           file={name}
           lines={prevCounts[name] ?? 0}
           initialRadius={info.r}
-          engine={engine}
-          width={width}
-          height={height}
           onReady={(handle) => {
             info.body = handle.body;
             info.handle = handle;
@@ -143,7 +141,13 @@ export const createFileSimulation = (
         info.el,
       ),
     );
-    flushSync(() => root.render(<>{portals}</>));
+    flushSync(() =>
+      root.render(
+        <PhysicsProvider bounds={{ width, height }} engine={engine}>
+          <>{portals}</>
+        </PhysicsProvider>,
+      ),
+    );
   };
 
   const spawnChar = (


### PR DESCRIPTION
## Summary
- update `PhysicsProvider` to accept external engines
- rely on `useBody` in `FileCircle`
- wrap portals with `PhysicsProvider` in `createFileSimulation`
- move transform logic into `FileCircle`
- update simulation loop

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684edebe76cc832aae54dc271af21511