### PR TITLE
test: ⏱️ ensure SeekBar onChange stability

### DIFF
--- a/src/__tests__/seekBar.test.tsx
+++ b/src/__tests__/seekBar.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { SeekBar } from '../client/components/SeekBar';
+
+describe('SeekBar', () => {
+  it('does not call onChange when value prop updates', () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <SeekBar value={0} min={0} max={10} onChange={onChange} />,
+    );
+    rerender(<SeekBar value={5} min={0} max={10} onChange={onChange} />);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a test verifying that SeekBar updates do not trigger onChange

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684ee89965ec832a875ca3d637c696ba