### PR TITLE
fix player raf bug

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -191,4 +191,38 @@ describe('createPlayer', () => {
     callbacks[1]?.(2000);
     expect(stateListener).toHaveBeenLastCalledWith(false);
   });
+
+  it('stops scheduling frames when paused', () => {
+    let seek = 0;
+    const getSeek = () => seek;
+    const setSeek = (v: number) => {
+      seek = v;
+    };
+
+    let cb: any = null;
+    const raf = jest.fn((fn: FrameRequestCallback) => {
+      cb = fn;
+      return 1;
+    });
+
+    const player = createPlayer({
+      getSeek,
+      setSeek,
+      duration: 1,
+      start: 0,
+      end: 2,
+      raf,
+      now: () => 0,
+    });
+
+    player.resume();
+    expect(raf).toHaveBeenCalledTimes(1);
+    if (cb) cb(0 as unknown as DOMHighResTimeStamp);
+    expect(raf).toHaveBeenCalledTimes(2);
+
+    player.pause();
+    if (cb) cb(16 as unknown as DOMHighResTimeStamp);
+
+    expect(raf).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -24,8 +24,6 @@ export const createPlayer = ({
 
   const tick = (time: number): void => {
     if (!playing) {
-      lastTime = time;
-      raf(tick);
       return;
     }
     const total = duration * 1000;


### PR DESCRIPTION
## Summary
- stop scheduling frames when not playing to prevent repeated events
- test that player stops scheduling after pause

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684eea23c8f8832aad8231c87c80fb62