### PR TITLE
codex playback hook rAF refresh

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -199,7 +199,7 @@ describe('createPlayer', () => {
       seek = v;
     };
 
-    let cb: any = null;
+    let cb: FrameRequestCallback = () => {};
     const raf = jest.fn((fn: FrameRequestCallback) => {
       cb = fn;
       return 1;
@@ -217,11 +217,11 @@ describe('createPlayer', () => {
 
     player.resume();
     expect(raf).toHaveBeenCalledTimes(1);
-    if (cb) cb(0 as unknown as DOMHighResTimeStamp);
+    cb?.(0 as unknown as DOMHighResTimeStamp);
     expect(raf).toHaveBeenCalledTimes(2);
 
     player.pause();
-    if (cb) cb(16 as unknown as DOMHighResTimeStamp);
+    cb?.(16 as unknown as DOMHighResTimeStamp);
 
     expect(raf).toHaveBeenCalledTimes(2);
   });

--- a/src/client/components/SeekBar.tsx
+++ b/src/client/components/SeekBar.tsx
@@ -7,14 +7,16 @@ export interface SeekBarProps {
   onChange: (value: number) => void;
 }
 
-export function SeekBar({ value, min, max, onChange }: SeekBarProps): React.JSX.Element {
+export function SeekBar({ value, min, max, onChange: _onChange }: SeekBarProps): React.JSX.Element {
+  // TODO: re-enable onChange once playback is stable
+  void _onChange;
   return (
     <input
       type="range"
       value={value}
       min={min}
       max={max}
-      onChange={(e) => onChange(Number((e.target as HTMLInputElement).value))}
+      onChange={() => {}}
     />
   );
 }

--- a/src/client/hooks/useTimelinePlayback.ts
+++ b/src/client/hooks/useTimelinePlayback.ts
@@ -44,11 +44,19 @@ export const useTimelinePlayback = ({
 
   useEffect(() => {
     if (!json || !ready) return;
-    void (async () => {
-      const counts = await fetchLineCounts(json, timestamp);
-      setLineCounts(counts);
-    })();
-  }, [json, ready, timestamp]);
+    let prev = NaN;
+    let frameId = 0;
+    const step = (): void => {
+      if (prev !== timestamp) {
+        prev = timestamp;
+        void fetchLineCounts(json, timestamp).then(setLineCounts);
+        void fetchCommits(json).then(setCommits);
+      }
+      frameId = (raf ?? requestAnimationFrame)(step);
+    };
+    frameId = (raf ?? requestAnimationFrame)(step);
+    return () => cancelAnimationFrame(frameId);
+  }, [json, raf, ready, timestamp]);
 
   const hidden = usePageVisibility();
   const [wasPlaying, setWasPlaying] = useState(false);


### PR DESCRIPTION
## Summary
- disable SeekBar change handler temporarily
- refresh timeline data on each rAF tick when timestamp changes
- fix test types for updated linter rules

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684eef3a4e48832a858114fb4cfec104