### PR TITLE
codex/fix-player-range

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -225,4 +225,35 @@ describe('createPlayer', () => {
 
     expect(raf).toHaveBeenCalledTimes(2);
   });
+
+  it('handles reversed ranges', () => {
+    let seek = 10;
+    const getSeek = () => seek;
+    const setSeek = (v: number) => {
+      seek = v;
+    };
+
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback) => {
+      callbacks.push(cb);
+      return 1;
+    };
+
+    const player = createPlayer({
+      getSeek,
+      setSeek,
+      duration: 1,
+      start: 10,
+      end: 0,
+      raf,
+      now: () => 0,
+    });
+
+    player.resume();
+    callbacks[0]?.(0);
+    callbacks[1]?.(1000);
+
+    expect(seek).toBe(0);
+    expect(player.isPlaying()).toBe(false);
+  });
 });

--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -21,18 +21,28 @@ export const createPlayer = ({
 }: PlayerOptions) => {
   let playing = false;
   let lastTime = 0;
+  const forward = end >= start;
+  const rangeStart = forward ? start : end;
+  const rangeEnd = forward ? end : start;
+  const direction = forward ? 1 : -1;
 
   const tick = (time: number): void => {
     if (!playing) {
       return;
     }
     const total = duration * 1000;
-    const factor = (end - start) / total;
-    const dt = (time - lastTime) * factor;
+    const factor = (rangeEnd - rangeStart) / total;
+    const dt = (time - lastTime) * factor * direction;
     lastTime = time;
-    const next = Math.min(getSeek() + dt, end);
+    const next = Math.max(
+      rangeStart,
+      Math.min(rangeEnd, getSeek() + dt),
+    );
     setSeek(next);
-    if (next < end) {
+    if (
+      (forward && next < rangeEnd) ||
+      (!forward && next > rangeStart)
+    ) {
       raf(tick);
     } else {
       setPlaying(false);


### PR DESCRIPTION
## Summary
- handle reversed start/end ranges in player
- test reversed ranges

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684ef13b32b0832a9e822dfc71ab1e8e