### PR TITLE
Add char and glow hooks

### DIFF
--- a/src/__tests__/useCharEffects.test.tsx
+++ b/src/__tests__/useCharEffects.test.tsx
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useCharEffects } from '../client/hooks/useCharEffects';
+
+describe('useCharEffects', () => {
+  it('spawns and removes characters', () => {
+    const { result } = renderHook(() => useCharEffects());
+    const onEnd = jest.fn();
+
+    act(() => {
+      result.current.spawnChar('add', { x: 0, y: 0 }, onEnd);
+    });
+    expect(result.current.chars).toHaveLength(1);
+
+    const id = result.current.chars[0]!.id;
+    act(() => {
+      result.current.removeChar(id);
+    });
+
+    expect(result.current.chars).toHaveLength(0);
+  });
+});

--- a/src/__tests__/useGlowControl.test.ts
+++ b/src/__tests__/useGlowControl.test.ts
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useGlowControl } from '../client/hooks/useGlowControl';
+
+describe('useGlowControl', () => {
+  it('starts and clears class', () => {
+    const { result } = renderHook(() => useGlowControl());
+
+    act(() => {
+      result.current.startGlow('glow');
+    });
+    expect(result.current.glowProps.className).toBe('glow');
+
+    act(() => {
+      result.current.glowProps.onAnimationEnd();
+    });
+    expect(result.current.glowProps.className).toBe('');
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -4,7 +4,7 @@ import { useBody } from '../hooks';
 import * as Physics from '../physics';
 import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
 import { colorForFile } from '../lines';
-import { useGlowAnimation } from '../hooks';
+import { useGlowControl } from '../hooks';
 
 export interface FileCircleHandle extends FileCircleContentHandle {
   body: Physics.Body;
@@ -37,7 +37,7 @@ export function FileCircle({
   const containerRef = useRef<HTMLDivElement>(null);
   const [contentHandle, setContentHandle] = useState<FileCircleContentHandle | null>(null);
   const [radius, setRadius] = useState(initialRadius);
-  const [startGlow, glowProps] = useGlowAnimation();
+  const { startGlow, glowProps } = useGlowControl();
   const [hidden, setHidden] = useState(false);
   useEffect(() => {
     Physics.Body.setPosition(body, {

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useId, useState } from 'react';
+import { useCharEffects } from '../hooks';
 
 export interface FileCircleContentHandle {
   setCount: (n: number) => void;
@@ -27,39 +28,16 @@ export function FileCircleContent({
 }: FileCircleContentProps): React.JSX.Element {
   const [currentCount, setCurrentCount] = useState(count);
   const charsId = useId();
-  const [chars, setChars] = useState<
-    Array<{
-      id: string;
-      cls: string;
-      char: string;
-      offset: { x: number; y: number };
-      rotate: string;
-      delay: number;
-      color?: string;
-      onEnd: () => void;
-    }>
-  >([]);
+  const { chars, spawnChar, removeChar } = useCharEffects();
 
   useEffect(() => {
     if (!onReady) return;
     const handle: FileCircleContentHandle = {
       setCount: setCurrentCount,
-      spawnChar: (cls, offset, onEnd, color) => {
-        const effect = {
-          id: Math.random().toString(36).slice(2),
-          cls,
-          char: Math.random().toString(36).charAt(2),
-          offset,
-          rotate: `${Math.random() * 360}deg`,
-          delay: Math.random() * 0.5,
-          onEnd,
-          ...(color ? { color } : {}),
-        };
-        setChars((prev) => [...prev, effect]);
-      },
+      spawnChar,
     };
     onReady(handle);
-  }, [onReady]);
+  }, [onReady, spawnChar]);
 
   return (
     <>
@@ -79,7 +57,7 @@ export function FileCircleContent({
               color: c.color,
             } as React.CSSProperties}
             onAnimationEnd={() => {
-              setChars((prev) => prev.filter((e) => e.id !== c.id));
+              removeChar(c.id);
               c.onEnd();
             }}
           >

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -126,6 +126,8 @@ export const usePlayer = (options: PlayerOptions) => {
 
 export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';
 export { useGlowAnimation } from './useGlowAnimation';
+export { useGlowControl } from './useGlowControl';
+export { useCharEffects } from './useCharEffects';
 export { usePageVisibility } from './usePageVisibility';
 export { usePhysics } from './usePhysics';
 export { PhysicsProvider, useEngine } from './useEngine';

--- a/src/client/hooks/useCharEffects.ts
+++ b/src/client/hooks/useCharEffects.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+
+interface CharEffect {
+  id: string;
+  cls: string;
+  char: string;
+  offset: { x: number; y: number };
+  rotate: string;
+  delay: number;
+  color?: string;
+  onEnd: () => void;
+}
+
+export interface CharEffects {
+  chars: CharEffect[];
+  spawnChar: (
+    cls: string,
+    offset: { x: number; y: number },
+    onEnd: () => void,
+    color?: string,
+  ) => void;
+  removeChar: (id: string) => void;
+}
+
+export const useCharEffects = (): CharEffects => {
+  const [chars, setChars] = useState<CharEffect[]>([]);
+
+  const removeChar = useCallback((id: string): void => {
+    setChars((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  const spawnChar = useCallback(
+    (
+      cls: string,
+      offset: { x: number; y: number },
+      onEnd: () => void,
+      color?: string,
+    ): void => {
+      const effect: CharEffect = {
+        id: Math.random().toString(36).slice(2),
+        cls,
+        char: Math.random().toString(36).charAt(2),
+        offset,
+        rotate: `${Math.random() * 360}deg`,
+        delay: Math.random() * 0.5,
+        onEnd,
+        ...(color ? { color } : {}),
+      };
+      setChars((prev) => [...prev, effect]);
+    },
+    [],
+  );
+
+  return { chars, spawnChar, removeChar };
+};

--- a/src/client/hooks/useGlowControl.ts
+++ b/src/client/hooks/useGlowControl.ts
@@ -1,0 +1,6 @@
+import { useGlowAnimation } from './useGlowAnimation';
+
+export const useGlowControl = () => {
+  const [startGlow, glowProps] = useGlowAnimation();
+  return { startGlow, glowProps } as const;
+};


### PR DESCRIPTION
## Summary
- create `useGlowControl` wrapper hook
- add `useCharEffects` for spawning characters
- refactor `FileCircleContent` to use `useCharEffects`
- refactor `FileCircle` to use `useGlowControl`
- test new hooks

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684ef486c470832ab783600c2bcf2e9e