### PR TITLE
feat(server): add ignore defaults

### DIFF
--- a/src/__tests__/lineCounts.test.ts
+++ b/src/__tests__/lineCounts.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
 import { getLineCounts } from '../lineCounts';
+import { defaultIgnore } from '../ignoreDefaults';
 
 const author = { name: 'a', email: 'a@example.com' };
 
@@ -30,5 +31,16 @@ describe('getLineCounts', () => {
 
     const counts = await getLineCounts({ dir, ref: 'HEAD' });
     expect(counts.find((c) => c.file === 'b.bin')).toBeUndefined();
+  });
+
+  it('ignores files matched by patterns', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    await fs.promises.writeFile(path.join(dir, 'package-lock.json'), '0');
+    await git.add({ fs, dir, filepath: 'package-lock.json' });
+    await git.commit({ fs, dir, author, message: 'init' });
+
+    const counts = await getLineCounts({ dir, ref: 'HEAD', ignore: defaultIgnore });
+    expect(counts.find((c) => c.file === 'package-lock.json')).toBeUndefined();
   });
 });

--- a/src/apiMiddleware.ts
+++ b/src/apiMiddleware.ts
@@ -4,6 +4,7 @@ import * as git from 'isomorphic-git';
 import fs from 'fs';
 import path from 'path';
 import { getLineCounts, LineCount } from './lineCounts';
+import { defaultIgnore } from './ignoreDefaults';
 
 export interface CreateApiMiddlewareOptions {
   repo?: string;
@@ -26,7 +27,11 @@ const resolveBranch = async (
   return branch;
 };
 
-export const createApiMiddleware = async ({ repo = process.cwd(), branch: inputBranch, ignore = [] }: CreateApiMiddlewareOptions = {}) => {
+export const createApiMiddleware = async ({
+  repo = process.cwd(),
+  branch: inputBranch,
+  ignore = [...defaultIgnore],
+}: CreateApiMiddlewareOptions = {}) => {
   const repoDir = path.resolve(repo);
   if (!fs.existsSync(path.join(repoDir, '.git'))) {
     throw new Error(`${repoDir} is not a git repository.`);

--- a/src/ignoreDefaults.ts
+++ b/src/ignoreDefaults.ts
@@ -1,0 +1,11 @@
+export const defaultIgnore = [
+  '**/*.lock',
+  '**/*lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'package-lock.json',
+  'Cargo.lock',
+  'go.sum',
+  'Pipfile.lock',
+  'composer.lock',
+];

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,18 +2,7 @@ import express from 'express';
 import { Command } from 'commander';
 import { apiMiddleware } from './apiMiddleware';
 import { appSettings } from './appSettings';
-
-const defaultIgnore = [
-  '**/*.lock',
-  '**/*lock.json',
-  'pnpm-lock.yaml',
-  'yarn.lock',
-  'package-lock.json',
-  'Cargo.lock',
-  'go.sum',
-  'Pipfile.lock',
-  'composer.lock',
-];
+import { defaultIgnore } from './ignoreDefaults';
 
 const collect = (val: string, acc: string[]): string[] => acc.concat(val.split(','));
 


### PR DESCRIPTION
## Summary
- add shared ignore list for lock files
- use ignore defaults in `createApiMiddleware`
- add tests ensuring lock files are ignored

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f6d0f76b4832abc251fc6a641218c