### PR TITLE
Fix redundant commit fetch

### DIFF
--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -32,6 +32,9 @@ describe('useTimelineData', () => {
     await waitFor(() =>
       expect(result.current.lineCounts).toEqual(linesSecond),
     );
+
+    expect(json.mock.calls.filter(([u]) => u.startsWith('/api/commits')).length).toBe(1);
+    expect(json.mock.calls).toHaveLength(3);
   });
 });
 

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -32,7 +32,6 @@ export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
   useEffect(() => {
     if (!json || !ready) return;
     void fetchLineCounts(json, timestamp).then(setLineCounts);
-    void fetchCommits(json).then(setCommits);
   }, [json, timestamp, ready]);
 
   return { commits, lineCounts, start, end, ready };


### PR DESCRIPTION
## Summary
- avoid fetching commits on every timestamp change
- verify commit request happens once in useTimelineData hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f6d52928c832ab7ac732df9abf211