### PR TITLE
Add key to FileCircle portals

### DIFF
--- a/src/client/lines.tsx
+++ b/src/client/lines.tsx
@@ -131,6 +131,7 @@ export const createFileSimulation = (
     const portals = Object.entries(bodies).map(([name, info]) =>
       createPortal(
         <FileCircle
+          key={name}
           file={name}
           lines={prevCounts[name] ?? 0}
           initialRadius={info.r}


### PR DESCRIPTION
## Summary
- preserve FileCircle component identity by adding a key when creating portals

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --json`

------
https://chatgpt.com/codex/tasks/task_e_684f6d7c095c832ab2eea0d0d889b42f