### PR TITLE
Ensure single API call

### DIFF
--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { App } from '../client/App';
+
+const commits = [
+  { commit: { message: 'new', committer: { timestamp: 2 } } },
+  { commit: { message: 'old', committer: { timestamp: 1 } } },
+];
+
+describe('App API calls', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      if (typeof input === 'string' && input.startsWith('/api/commits')) {
+        return Promise.resolve({ json: () => Promise.resolve(commits) });
+      }
+      if (typeof input === 'string' && input.startsWith('/api/lines')) {
+        return Promise.resolve({ json: () => Promise.resolve([]) });
+      }
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('fetches commits once and lines on timestamp change', async () => {
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
+    const fetchMock = global.fetch as jest.Mock;
+    expect(
+      fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/commits')),
+    ).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/lines')),
+    ).toHaveLength(1);
+
+    const input = container.querySelector('input[type="range"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1500' } });
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/lines')).length,
+      ).toBe(2),
+    );
+    expect(
+      fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/commits')),
+    ).toHaveLength(1);
+  });
+});

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { CommitLog } from './components/CommitLog';
 import { SeekBar } from './components/SeekBar';
 import { FileCircleSimulation } from './components/FileCircleSimulation';
@@ -7,15 +7,14 @@ import { useTimelineData } from './hooks';
 export function App(): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
 
-  const {
-    commits,
-    lineCounts,
-    start,
-    end,
-    ready,
-  } = useTimelineData({
+  const json = useCallback(
+    (input: string) => fetch(input).then((r) => r.json()),
+    [],
+  );
+
+  const { commits, lineCounts, start, end, ready } = useTimelineData({
     timestamp,
-    json: (input: string) => fetch(input).then((r) => r.json()),
+    json,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stabilize fetcher in `App` to avoid repeated effects
- add regression test for API call counts

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f7027fc54832aa003e9feed67f482