### PR TITLE
refactor(server): 🗑️ remove API middleware factory

### DIFF
--- a/playwright/ui.spec.ts
+++ b/playwright/ui.spec.ts
@@ -5,7 +5,8 @@ import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import { test, expect } from '@playwright/test';
 import express from 'express';
-import { createApiMiddleware } from '../src/apiMiddleware';
+import { apiMiddleware } from '../src/apiMiddleware';
+import { appSettings } from '../src/appSettings';
 
 const author = { name: 'a', email: 'a@example.com' };
 
@@ -17,8 +18,10 @@ test('serves index page', async ({ page }) => {
   await git.commit({ fs, dir, author, message: 'init' });
 
   const app = express();
+  app.set(appSettings.repo.description!, dir);
+  app.set(appSettings.branch.description!, 'HEAD');
   app.use(express.static('dist'));
-  app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
+  app.use(apiMiddleware);
   const server = app.listen(0);
   const { port } = server.address() as AddressInfo;
 

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import express from 'express';
-import { createApiMiddleware, apiMiddleware } from '../apiMiddleware';
+import { apiMiddleware } from '../apiMiddleware';
 import { appSettings } from '../appSettings';
 import { fetchCommits, fetchLineCounts, JsonFetcher } from '../client/api';
 
@@ -23,7 +23,9 @@ describe('server e2e', () => {
     await git.commit({ fs, dir, author, message: 'init' });
 
     const app = express();
-    app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
+    app.set(appSettings.repo.description!, dir);
+    app.set(appSettings.branch.description!, 'HEAD');
+    app.use(apiMiddleware);
     const server = app.listen(0);
     const { port } = server.address() as AddressInfo;
 
@@ -74,7 +76,9 @@ describe('server e2e', () => {
     await git.commit({ fs, dir, author, message: 'init' });
 
     const app = express();
-    app.use(await createApiMiddleware({ repo: dir, branch: 'HEAD' }));
+    app.set(appSettings.repo.description!, dir);
+    app.set(appSettings.branch.description!, 'HEAD');
+    app.use(apiMiddleware);
     const server = app.listen(0);
     const { port } = server.address() as AddressInfo;
 

--- a/src/viteExpress.ts
+++ b/src/viteExpress.ts
@@ -1,15 +1,14 @@
 import type { Plugin } from 'vite';
 import type { NextHandleFunction } from 'connect';
-import { createApiMiddleware } from './apiMiddleware';
+import { apiMiddleware } from './apiMiddleware';
 import express from 'express';
 
 export default function viteExpress(): Plugin {
   return {
     name: 'vite-express',
-    async configureServer(server) {
-      const router = await createApiMiddleware();
+    configureServer(server) {
       const app = express();
-      app.use(router);
+      app.use(apiMiddleware);
       server.middlewares.use(app as unknown as NextHandleFunction);
     },
   };


### PR DESCRIPTION
## Summary
- drop `createApiMiddleware`
- configure middleware via `app.set`
- update server tests and plugin

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684f70c62de4832a870de9cbd5d68a30