### PR TITLE
fix timestamp range with min/max calculation

### DIFF
--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -20,8 +20,9 @@ export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
       const data = await fetchCommits(json);
       setCommits(data);
       if (data.length) {
-        const s = data[data.length - 1]!.commit.committer.timestamp * 1000;
-        const e = data[0]!.commit.committer.timestamp * 1000;
+        const timestamps = data.map((c) => c.commit.committer.timestamp * 1000);
+        const s = Math.min(...timestamps);
+        const e = Math.max(...timestamps);
         setStart(s);
         setEnd(e);
       }


### PR DESCRIPTION
## Summary
- ensure timestamp range uses min/max in `useTimelineData`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit --omit dev`


------
https://chatgpt.com/codex/tasks/task_e_684f7168961c832abee152fe1dd6a6e9