### PR TITLE
Fix colorForFile for extensionless names

### DIFF
--- a/src/__tests__/colorForFile.test.ts
+++ b/src/__tests__/colorForFile.test.ts
@@ -1,0 +1,12 @@
+import { colorForFile } from '../client/lines';
+
+describe('colorForFile', () => {
+  it('handles extension case-insensitively', () => {
+    const color = colorForFile('file.TS');
+    expect(color.includes('52.222')).toBe(true);
+  });
+
+  it('handles files without extension', () => {
+    expect(colorForFile('Makefile')).toBe('hsl(8,60%,60%)');
+  });
+});

--- a/src/client/lines.tsx
+++ b/src/client/lines.tsx
@@ -55,7 +55,8 @@ const hsl = ({ h, s, l }: { h: number; s: number; l: number }): string =>
   `hsl(${h},${s}%,${l}%)`;
 
 export const colorForFile = (name: string): string => {
-  const ext = name.slice(name.lastIndexOf('.'));
+  const i = name.lastIndexOf('.');
+  const ext = i >= 0 ? name.slice(i).toLowerCase() : '';
   const offset = (hashHue(name) % 20) - 10;
   const base = fileColors[ext];
   if (base) {


### PR DESCRIPTION
## Summary
- test edge cases of colorForFile
- handle filenames without extensions in colorForFile

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f7187df3c832a971c13ab3298ede4