### PR TITLE
Refactor simulation utilities

### DIFF
--- a/src/__tests__/colorForFile.test.ts
+++ b/src/__tests__/colorForFile.test.ts
@@ -1,4 +1,4 @@
-import { colorForFile } from '../client/lines';
+import { colorForFile } from '../client/colors';
 
 describe('colorForFile', () => {
   it('handles extension case-insensitively', () => {

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -2,10 +2,10 @@
 import { fetchLineCounts } from '../client/api';
 import {
   renderFileSimulation,
-  computeScale,
   createFileSimulation,
   MAX_EFFECT_CHARS,
-} from '../client/lines';
+} from '../client/fileSimulation';
+import { computeScale } from '../client/scale';
 import { act } from '@testing-library/react';
 import type { LineCount } from '../client/types';
 

--- a/src/__tests__/useAnimatedSimulation.test.ts
+++ b/src/__tests__/useAnimatedSimulation.test.ts
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
 import { useAnimatedSimulation } from '../client/hooks';
-import { createFileSimulation } from '../client/lines';
+import { createFileSimulation } from '../client/fileSimulation';
 import type { LineCount } from '../client/types';
 
-jest.mock('../client/lines');
+jest.mock('../client/fileSimulation');
 
 const mockSim = {
   update: jest.fn(),

--- a/src/__tests__/useFileSimulation.options.test.ts
+++ b/src/__tests__/useFileSimulation.options.test.ts
@@ -1,9 +1,9 @@
 /** @jest-environment jsdom */
 import { renderHook } from '@testing-library/react';
 import { useFileSimulation } from '../client/hooks';
-import { createFileSimulation } from '../client/lines';
+import { createFileSimulation } from '../client/fileSimulation';
 
-jest.mock('../client/lines');
+jest.mock('../client/fileSimulation');
 
 const mockSim = {
   update: jest.fn(),

--- a/src/__tests__/useFileSimulation.test.ts
+++ b/src/__tests__/useFileSimulation.test.ts
@@ -1,9 +1,9 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
 import { useFileSimulation } from '../client/hooks';
-import { createFileSimulation } from '../client/lines';
+import { createFileSimulation } from '../client/fileSimulation';
 
-jest.mock('../client/lines');
+jest.mock('../client/fileSimulation');
 
 const mockSim = {
   update: jest.fn(),

--- a/src/__tests__/useFileSimulationRef.test.ts
+++ b/src/__tests__/useFileSimulationRef.test.ts
@@ -1,9 +1,9 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
 import { useFileSimulationRef } from '../client/hooks';
-import { createFileSimulation } from '../client/lines';
+import { createFileSimulation } from '../client/fileSimulation';
 
-jest.mock('../client/lines');
+jest.mock('../client/fileSimulation');
 
 const mockSim = {
   update: jest.fn(),

--- a/src/client/colors.ts
+++ b/src/client/colors.ts
@@ -1,0 +1,54 @@
+export const fileColors: Record<string, string> = {
+  '.ts': '#2b7489',
+  '.js': '#f1e05a',
+  '.json': '#292929',
+  '.md': '#083fa1',
+  '.html': '#e34c26',
+  '.css': '#563d7c',
+};
+
+const hashHue = (s: string): number =>
+  Array.from(s).reduce((a, c) => a + c.charCodeAt(0), 0) % 360;
+
+const hexToHsl = (
+  hex: string,
+): { h: number; s: number; l: number } => {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l: l * 100 };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  switch (max) {
+    case r:
+      h = (g - b) / d + (g < b ? 6 : 0);
+      break;
+    case g:
+      h = (b - r) / d + 2;
+      break;
+    default:
+      h = (r - g) / d + 4;
+  }
+  h *= 60;
+  return { h, s: s * 100, l: l * 100 };
+};
+
+const hsl = ({ h, s, l }: { h: number; s: number; l: number }): string =>
+  `hsl(${h},${s}%,${l}%)`;
+
+export const colorForFile = (name: string): string => {
+  const i = name.lastIndexOf('.');
+  const ext = i >= 0 ? name.slice(i).toLowerCase() : '';
+  const offset = (hashHue(name) % 20) - 10;
+  const base = fileColors[ext];
+  if (base) {
+    const { h, s, l } = hexToHsl(base);
+    return hsl({ h: (h + offset + 360) % 360, s, l });
+  }
+  const hue = (hashHue(ext) + offset + 360) % 360;
+  return `hsl(${hue},60%,60%)`;
+};

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useId, useState, useCallback, useRef } from 'react';
 import { useBody } from '../hooks';
 import * as Physics from '../physics';
 import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
-import { colorForFile } from '../lines';
+import { colorForFile } from '../colors';
 import { useGlowControl } from '../hooks';
 
 export interface FileCircleHandle extends FileCircleContentHandle {

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { PhysicsProvider, useEngine } from '../hooks';
 import { FileCircle, type FileCircleHandle } from './FileCircle';
 import type { LineCount } from '../types';
-import { computeScale } from '../lines';
+import { computeScale } from '../scale';
 import { Body, Engine } from '../physics';
 
 interface FileCircleSimulationProps {

--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -5,6 +5,7 @@ import { createPortal, flushSync } from 'react-dom';
 import { FileCircle, type FileCircleHandle } from './components/FileCircle';
 import { PhysicsProvider } from './hooks';
 import * as Physics from './physics';
+import { computeScale } from './scale';
 const { Body, Composite, Engine } = Physics;
 
 const MIN_CIRCLE_SIZE = 1;
@@ -12,95 +13,12 @@ const CHAR_ANIMATION_MS = 1500;
 export const EFFECT_DROP_THRESHOLD = 50;
 export const MAX_EFFECT_CHARS = 100;
 
-const fileColors: Record<string, string> = {
-  '.ts': '#2b7489',
-  '.js': '#f1e05a',
-  '.json': '#292929',
-  '.md': '#083fa1',
-  '.html': '#e34c26',
-  '.css': '#563d7c',
-};
-
-const hashHue = (s: string): number =>
-  Array.from(s).reduce((a, c) => a + c.charCodeAt(0), 0) % 360;
-
-const hexToHsl = (
-  hex: string,
-): { h: number; s: number; l: number } => {
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-  if (max === min) return { h: 0, s: 0, l: l * 100 };
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  let h = 0;
-  switch (max) {
-    case r:
-      h = (g - b) / d + (g < b ? 6 : 0);
-      break;
-    case g:
-      h = (b - r) / d + 2;
-      break;
-    default:
-      h = (r - g) / d + 4;
-  }
-  h *= 60;
-  return { h, s: s * 100, l: l * 100 };
-};
-
-const hsl = ({ h, s, l }: { h: number; s: number; l: number }): string =>
-  `hsl(${h},${s}%,${l}%)`;
-
-export const colorForFile = (name: string): string => {
-  const i = name.lastIndexOf('.');
-  const ext = i >= 0 ? name.slice(i).toLowerCase() : '';
-  const offset = (hashHue(name) % 20) - 10;
-  const base = fileColors[ext];
-  if (base) {
-    const { h, s, l } = hexToHsl(base);
-    return hsl({ h: (h + offset + 360) % 360, s, l });
-  }
-  const hue = (hashHue(ext) + offset + 360) % 360;
-  return `hsl(${hue},60%,60%)`;
-};
-
-
 interface BodyInfo {
   el: HTMLElement;
   body?: Physics.Body;
   r: number;
   handle?: FileCircleHandle;
 }
-
-export const computeScale = (
-  width: number,
-  height: number,
-  data: LineCount[],
-  opts: { linear?: boolean } = {},
-): number => {
-  if (!Array.isArray(data)) return 0;
-  const exp = opts.linear ? 1 : 0.5;
-  const maxLines = data.reduce(
-    (m, d) => Math.max(m, Number.isFinite(d.lines) ? d.lines : 0),
-    1,
-  );
-  const base = Math.min(width, height) / Math.pow(maxLines, exp);
-  const totalArea = data.reduce(
-    (sum, f) => {
-      const lines = Number.isFinite(f.lines) ? f.lines : 0;
-      return sum + Math.PI * ((Math.pow(lines, exp) * base) / 2) ** 2;
-    },
-    0,
-  );
-  const ratio = totalArea / (width * height);
-  const threshold = 0.15;
-  if (!Number.isFinite(ratio) || ratio <= threshold) return base;
-  const easing = Math.pow(threshold / ratio, 0.25);
-  return base * easing;
-};
 
 export const createFileSimulation = (
   container: HTMLElement,

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { createFileSimulation } from '../lines';
+import { createFileSimulation } from '../fileSimulation';
 import { createPlayer } from '../player';
 import type { LineCount } from '../types';
 import type { PlayerOptions } from '../player';

--- a/src/client/scale.ts
+++ b/src/client/scale.ts
@@ -1,0 +1,28 @@
+import type { LineCount } from './types';
+
+export const computeScale = (
+  width: number,
+  height: number,
+  data: LineCount[],
+  opts: { linear?: boolean } = {},
+): number => {
+  if (!Array.isArray(data)) return 0;
+  const exp = opts.linear ? 1 : 0.5;
+  const maxLines = data.reduce(
+    (m, d) => Math.max(m, Number.isFinite(d.lines) ? d.lines : 0),
+    1,
+  );
+  const base = Math.min(width, height) / Math.pow(maxLines, exp);
+  const totalArea = data.reduce(
+    (sum, f) => {
+      const lines = Number.isFinite(f.lines) ? f.lines : 0;
+      return sum + Math.PI * ((Math.pow(lines, exp) * base) / 2) ** 2;
+    },
+    0,
+  );
+  const ratio = totalArea / (width * height);
+  const threshold = 0.15;
+  if (!Number.isFinite(ratio) || ratio <= threshold) return base;
+  const easing = Math.pow(threshold / ratio, 0.25);
+  return base * easing;
+};


### PR DESCRIPTION
## Summary
- split utilities from `lines.tsx`
- move color helpers to `colors.ts`
- move computeScale to `scale.ts`
- move simulation logic to `fileSimulation.tsx`
- update imports and tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f7339d5e8832a919a7209bb545409