### PR TITLE
Add typed API responses with validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "express": "^5.1.0",
         "isomorphic-git": "^1.30.3",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zod": "^3.25.64"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -12059,6 +12060,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "express": "^5.1.0",
     "isomorphic-git": "^1.30.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@playwright/test": "^1.53.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.3.0",
@@ -31,7 +33,7 @@
     "@types/react-dom": "^19.1.6",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
-    "@eslint/eslintrc": "^3.3.1",
+    "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^9.29.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -41,8 +43,7 @@
     "ts-jest": "^29.4.0",
     "tsx": "^4.6.3",
     "typescript": "^5.2.2",
-    "vite": "^6.3.5",
-    "@vitejs/plugin-react": "^4.5.2"
+    "vite": "^6.3.5"
   },
   "overrides": {
     "test-exclude": "^7.0.1"

--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -16,10 +16,10 @@ describe('App commit log', () => {
     document.body.innerHTML = '<div id="root"></div>';
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
-        return Promise.resolve({ json: () => Promise.resolve(commits) });
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve([]) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -16,10 +16,10 @@ describe('App API calls', () => {
     document.body.innerHTML = '<div id="root"></div>';
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
-        return Promise.resolve({ json: () => Promise.resolve(commits) });
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve([]) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/commits.test.ts
+++ b/src/__tests__/commits.test.ts
@@ -1,12 +1,13 @@
 /** @jest-environment jsdom */
 import { fetchCommits } from '../client/api';
-import type { Commit } from '../client/types';
 
 describe('commits module', () => {
   it('fetches commits', async () => {
-    const json = jest.fn().mockResolvedValue([
-      { commit: { message: 'msg', committer: { timestamp: 1 } } },
-    ] as Commit[]);
+    const json = jest.fn().mockResolvedValue({
+      commits: [
+        { commit: { message: 'msg', committer: { timestamp: 1 } } },
+      ],
+    });
     await expect(fetchCommits(json)).resolves.toEqual([
       { commit: { message: 'msg', committer: { timestamp: 1 } } },
     ]);

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -10,13 +10,15 @@ describe('client index', () => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
         return Promise.resolve({
           json: () =>
-            Promise.resolve([
-              { commit: { message: 'msg', committer: { timestamp: 1 } } },
-            ]),
+            Promise.resolve({
+              commits: [
+                { commit: { message: 'msg', committer: { timestamp: 1 } } },
+              ],
+            }),
         });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve([]) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -11,7 +11,7 @@ import type { LineCount } from '../client/types';
 
 describe('lines module', () => {
   it('fetches line counts with timestamp', async () => {
-    const json = jest.fn().mockResolvedValue([{ file: 'a', lines: 1 }] as LineCount[]);
+    const json = jest.fn().mockResolvedValue({ counts: [{ file: 'a', lines: 1 }] });
     await expect(fetchLineCounts(json, 100)).resolves.toEqual([{ file: 'a', lines: 1 }]);
     expect(json).toHaveBeenCalledWith('/api/lines?ts=100');
   });

--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -11,9 +11,9 @@ describe('useTimelineData', () => {
     const linesFirst = [{ file: 'a', lines: 1 }];
     const linesSecond = [{ file: 'a', lines: 2 }];
     const json = jest.fn((input: string) => {
-      if (input.startsWith('/api/commits')) return Promise.resolve(commits);
-      if (input === '/api/lines?ts=0') return Promise.resolve(linesFirst);
-      if (input === '/api/lines?ts=1') return Promise.resolve(linesSecond);
+      if (input.startsWith('/api/commits')) return Promise.resolve({ commits });
+      if (input === '/api/lines?ts=0') return Promise.resolve({ counts: linesFirst });
+      if (input === '/api/lines?ts=1') return Promise.resolve({ counts: linesSecond });
       return Promise.reject(new Error(`unexpected ${input}`));
     });
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,13 @@
+import type { Commit, LineCount } from '../client/types';
+
+export interface ApiError {
+  error: string;
+}
+
+export interface CommitsResponse {
+  commits: Commit[];
+}
+
+export interface LineCountsResponse {
+  counts: LineCount[];
+}

--- a/src/apiMiddleware.ts
+++ b/src/apiMiddleware.ts
@@ -1,10 +1,38 @@
 import express from 'express';
+import { z } from 'zod';
 import { appSettings } from './appSettings';
 import * as git from 'isomorphic-git';
 import fs from 'fs';
 import path from 'path';
 import { getLineCounts } from './lineCounts';
 import { defaultIgnore } from './ignoreDefaults';
+import type {
+  ApiError,
+  CommitsResponse,
+  LineCountsResponse,
+} from './api/types';
+
+const commitSchema = z.object({
+  commit: z.object({
+    message: z.string(),
+    committer: z.object({ timestamp: z.number() }),
+  }),
+});
+
+const lineCountSchema = z.object({
+  file: z.string(),
+  lines: z.number(),
+});
+
+const commitsResponseSchema = z.object({
+  commits: z.array(commitSchema),
+});
+
+const lineCountsResponseSchema = z.object({
+  counts: z.array(lineCountSchema),
+});
+
+const linesQuerySchema = z.object({ ts: z.string().optional() });
 
 const resolveBranch = async (
   dir: string,
@@ -29,55 +57,87 @@ const repoDir = (app: express.Application): string =>
 const ignorePatterns = (app: express.Application): string[] =>
   (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [...defaultIgnore];
 
-apiMiddleware.get('/api/commits', async (req, res) => {
-  const app = req.app;
-  const dir = repoDir(app);
-  if (!fs.existsSync(path.join(dir, '.git'))) {
-    res.status(500).json({ error: `${dir} is not a git repository.` });
-    return;
-  }
-  try {
-    const branch = await resolveBranch(
-      dir,
-      app.get(appSettings.branch.description!) as string | undefined,
-    );
-    const commits = await git.log({ fs, dir, ref: branch });
-    res.json(commits);
-  } catch (error) {
-    res.status(500).json({ error: (error as Error).message });
-  }
-});
-
-apiMiddleware.get('/api/lines', async (req, res) => {
-  const app = req.app;
-  const dir = repoDir(app);
-  if (!fs.existsSync(path.join(dir, '.git'))) {
-    res.status(500).json({ error: `${dir} is not a git repository.` });
-    return;
-  }
-  try {
-    const branch = await resolveBranch(
-      dir,
-      app.get(appSettings.branch.description!) as string | undefined,
-    );
-    const tsParam = req.query.ts as string | undefined;
-    const ignore = ignorePatterns(app);
-
-    const baseCounts = await getLineCounts({ dir, ref: branch, ignore });
-    if (tsParam) {
-      const ts = Number(tsParam) / 1000;
+apiMiddleware.get(
+  '/api/commits',
+  async (
+    req: express.Request<Record<string, never>, CommitsResponse | ApiError>,
+    res: express.Response<CommitsResponse | ApiError>,
+  ) => {
+    const app = req.app;
+    const dir = repoDir(app);
+    if (!fs.existsSync(path.join(dir, '.git'))) {
+      res.status(500).json({ error: `${dir} is not a git repository.` });
+      return;
+    }
+    try {
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
       const commits = await git.log({ fs, dir, ref: branch });
-      const commit = commits.find((c) => c.commit.committer.timestamp <= ts);
-      if (!commit) {
-        res.status(404).json({ error: 'Commit not found' });
+      const parsed = commitsResponseSchema.safeParse({ commits });
+      if (!parsed.success) {
+        res.status(500).json({ error: 'Invalid data' });
         return;
       }
-      const counts = await getLineCounts({ dir, ref: commit.oid, ignore });
-      res.json(counts);
-    } else {
-      res.json(baseCounts);
+      res.json(parsed.data);
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
     }
-  } catch (error) {
-    res.status(500).json({ error: (error as Error).message });
-  }
-});
+  },
+);
+
+apiMiddleware.get(
+  '/api/lines',
+  async (
+    req: express.Request<Record<string, never>, LineCountsResponse | ApiError, undefined, { ts?: string }>,
+    res: express.Response<LineCountsResponse | ApiError>,
+  ) => {
+    const app = req.app;
+    const dir = repoDir(app);
+    if (!fs.existsSync(path.join(dir, '.git'))) {
+      res.status(500).json({ error: `${dir} is not a git repository.` });
+      return;
+    }
+    try {
+      const branch = await resolveBranch(
+        dir,
+        app.get(appSettings.branch.description!) as string | undefined,
+      );
+      const query = linesQuerySchema.safeParse(req.query);
+      if (!query.success) {
+        res.status(400).json({ error: 'Invalid query' });
+        return;
+      }
+      const tsParam = query.data.ts;
+      const ignore = ignorePatterns(app);
+
+      const baseCounts = await getLineCounts({ dir, ref: branch, ignore });
+      if (tsParam) {
+        const ts = Number(tsParam) / 1000;
+        const commits = await git.log({ fs, dir, ref: branch });
+        const commit = commits.find((c) => c.commit.committer.timestamp <= ts);
+        if (!commit) {
+          res.status(404).json({ error: 'Commit not found' });
+          return;
+        }
+        const counts = await getLineCounts({ dir, ref: commit.oid, ignore });
+        const parsed = lineCountsResponseSchema.safeParse({ counts });
+        if (!parsed.success) {
+          res.status(500).json({ error: 'Invalid data' });
+          return;
+        }
+        res.json(parsed.data);
+      } else {
+        const parsed = lineCountsResponseSchema.safeParse({ counts: baseCounts });
+        if (!parsed.success) {
+          res.status(500).json({ error: 'Invalid data' });
+          return;
+        }
+        res.json(parsed.data);
+      }
+    } catch (error) {
+      res.status(500).json({ error: (error as Error).message });
+    }
+  },
+);

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,11 +1,16 @@
 import type { Commit, LineCount } from './types';
+import type { ApiError, CommitsResponse, LineCountsResponse } from '../api/types';
 
 export type JsonFetcher = (input: string) => Promise<unknown>;
 
 export const fetchCommits = async (
   json: JsonFetcher,
 ): Promise<Commit[]> => {
-  return (await json('/api/commits')) as Commit[];
+  const data = (await json('/api/commits')) as CommitsResponse | ApiError;
+  if ('commits' in data) {
+    return data.commits;
+  }
+  throw new Error(data.error);
 };
 
 export const fetchLineCounts = async (
@@ -14,6 +19,9 @@ export const fetchLineCounts = async (
 ): Promise<LineCount[]> => {
   const url =
     timestamp === undefined ? '/api/lines' : `/api/lines?ts=${timestamp}`;
-  const data = await json(url);
-  return Array.isArray(data) ? (data as LineCount[]) : [];
+  const result = (await json(url)) as LineCountsResponse | ApiError;
+  if ('counts' in result) {
+    return result.counts;
+  }
+  throw new Error(result.error);
 };


### PR DESCRIPTION
## Summary
- define ApiError and success response types
- validate API input and output with `zod`
- return typed objects from middleware
- parse new structure in client helpers
- update tests for new API schema

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f74ef8440832abbc5cf02b56f5d6d