### PR TITLE
Use global fetch for API calls

### DIFF
--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -19,7 +19,7 @@ describe('App commit log', () => {
         return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -19,7 +19,7 @@ describe('App API calls', () => {
         return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/commits.test.ts
+++ b/src/__tests__/commits.test.ts
@@ -2,13 +2,22 @@
 import { fetchCommits } from '../client/api';
 
 describe('commits module', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
   it('fetches commits', async () => {
-    const json = jest.fn().mockResolvedValue({
-      commits: [
-        { commit: { message: 'msg', committer: { timestamp: 1 } } },
-      ],
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          commits: [
+            { commit: { message: 'msg', committer: { timestamp: 1 } } },
+          ],
+        }),
     });
-    await expect(fetchCommits(json)).resolves.toEqual([
+    await expect(fetchCommits()).resolves.toEqual([
       { commit: { message: 'msg', committer: { timestamp: 1 } } },
     ]);
   });

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -18,7 +18,7 @@ describe('client index', () => {
         });
       }
       if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: [] }) });
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CommitLog } from './components/CommitLog';
 import { SeekBar } from './components/SeekBar';
 import { FileCircleSimulation } from './components/FileCircleSimulation';
@@ -7,14 +7,8 @@ import { useTimelineData } from './hooks';
 export function App(): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
 
-  const json = useCallback(
-    (input: string) => fetch(input).then((r) => r.json()),
-    [],
-  );
-
   const { commits, lineCounts, start, end, ready } = useTimelineData({
     timestamp,
-    json,
   });
 
   useEffect(() => {

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
-import { fetchCommits, fetchLineCounts, type JsonFetcher } from '../api';
+import { fetchCommits, fetchLineCounts } from '../api';
 import type { Commit, LineCount } from '../types';
 
 interface TimelineDataOptions {
-  json?: JsonFetcher | undefined;
+  baseUrl?: string | undefined;
   timestamp: number;
 }
 
-export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
+export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => {
   const [commits, setCommits] = useState<Commit[]>([]);
   const [lineCounts, setLineCounts] = useState<LineCount[]>([]);
   const [start, setStart] = useState(0);
@@ -15,9 +15,8 @@ export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    if (!json) return;
     void (async () => {
-      const data = await fetchCommits(json);
+      const data = await fetchCommits(baseUrl);
       setCommits(data);
       if (data.length) {
         const s = data[data.length - 1]!.commit.committer.timestamp * 1000;
@@ -27,12 +26,12 @@ export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
       }
       setReady(true);
     })();
-  }, [json]);
+  }, [baseUrl]);
 
   useEffect(() => {
-    if (!json || !ready) return;
-    void fetchLineCounts(json, timestamp).then(setLineCounts);
-  }, [json, timestamp, ready]);
+    if (!ready) return;
+    void fetchLineCounts(timestamp, baseUrl).then(setLineCounts);
+  }, [timestamp, ready, baseUrl]);
 
   return { commits, lineCounts, start, end, ready };
 };


### PR DESCRIPTION
## Summary
- use `fetch` directly in API helpers
- propagate optional base URL through `useTimelineData`
- treat empty line counts as API errors
- update tests for new API behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f771f5730832a8beec1f8e3db316c