### PR TITLE
Add timestamp assertion and fix initial API call

### DIFF
--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -60,4 +60,22 @@ describe('App API calls', () => {
       fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/commits')),
     ).toHaveLength(1);
   });
+
+  it('passes the timestamp in the lines API request', async () => {
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
+    const fetchMock = global.fetch as jest.Mock;
+    const calls = fetchMock.mock.calls as Array<[string]>;
+    const first = calls.find(([u]) => typeof u === 'string' && u.startsWith('/api/lines'));
+    expect(first?.[0]).toBe('/api/lines?ts=1000');
+
+    const input = container.querySelector('input[type="range"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1500' } });
+
+    await waitFor(() =>
+      calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/lines')).length === 2,
+    );
+    const second = calls.filter(([u]) => typeof u === 'string' && u.startsWith('/api/lines'))[1];
+    expect(second?.[0]).toBe('/api/lines?ts=1500');
+  });
 });

--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -12,7 +12,7 @@ describe('useTimelineData', () => {
     const linesSecond = [{ file: 'a', lines: 2 }];
     const json = jest.fn((input: string) => {
       if (input.startsWith('/api/commits')) return Promise.resolve({ commits });
-      if (input === '/api/lines?ts=0') return Promise.resolve({ counts: linesFirst });
+      if (input === '/api/lines?ts=1000') return Promise.resolve({ counts: linesFirst });
       if (input === '/api/lines?ts=1') return Promise.resolve({ counts: linesSecond });
       return Promise.reject(new Error(`unexpected ${input}`));
     });

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -31,8 +31,9 @@ export const useTimelineData = ({ json, timestamp }: TimelineDataOptions) => {
 
   useEffect(() => {
     if (!json || !ready) return;
-    void fetchLineCounts(json, timestamp).then(setLineCounts);
-  }, [json, timestamp, ready]);
+    const ts = timestamp || start;
+    void fetchLineCounts(json, ts).then(setLineCounts);
+  }, [json, timestamp, ready, start]);
 
   return { commits, lineCounts, start, end, ready };
 };


### PR DESCRIPTION
## Summary
- ensure first `/api/lines` call uses start timestamp
- verify timestamp usage with tests

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684f777f7ca0832aae52c2065633d4d0