### PR TITLE
Simplify commit API response

### DIFF
--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -4,8 +4,8 @@ import { render, waitFor } from '@testing-library/react';
 import { App } from '../client/App';
 
 const commits = [
-  { commit: { message: 'new', committer: { timestamp: 2 } } },
-  { commit: { message: 'old', committer: { timestamp: 1 } } },
+  { message: 'new', timestamp: 2 },
+  { message: 'old', timestamp: 1 },
 ];
 
 describe('App commit log', () => {

--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -4,8 +4,8 @@ import { render, waitFor, fireEvent } from '@testing-library/react';
 import { App } from '../client/App';
 
 const commits = [
-  { commit: { message: 'new', committer: { timestamp: 2 } } },
-  { commit: { message: 'old', committer: { timestamp: 1 } } },
+  { message: 'new', timestamp: 2 },
+  { message: 'old', timestamp: 1 },
 ];
 
 describe('App API calls', () => {

--- a/src/__tests__/commitLog.test.tsx
+++ b/src/__tests__/commitLog.test.tsx
@@ -7,8 +7,8 @@ import type { Commit } from '../client/types';
 describe('CommitLog', () => {
   it('highlights current commit on timestamp change', () => {
     const commits: Commit[] = [
-      { commit: { message: 'new', committer: { timestamp: 2 } } },
-      { commit: { message: 'old', committer: { timestamp: 1 } } },
+      { message: 'new', timestamp: 2 },
+      { message: 'old', timestamp: 1 },
     ];
     const { container, rerender } = render(
       <CommitLog commits={commits} timestamp={1500} visible={2} />,

--- a/src/__tests__/commits.test.ts
+++ b/src/__tests__/commits.test.ts
@@ -13,12 +13,12 @@ describe('commits module', () => {
       json: () =>
         Promise.resolve({
           commits: [
-            { commit: { message: 'msg', committer: { timestamp: 1 } } },
+            { message: 'msg', timestamp: 1 },
           ],
         }),
     });
     await expect(fetchCommits()).resolves.toEqual([
-      { commit: { message: 'msg', committer: { timestamp: 1 } } },
+      { message: 'msg', timestamp: 1 },
     ]);
   });
 });

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -30,7 +30,7 @@ describe('server e2e', () => {
     const commits = await fetchCommits(base);
     const counts = await fetchLineCounts(undefined, base);
 
-    expect(commits[0]!.commit.message).toBe('init\n');
+    expect(commits[0]!.message).toBe('init\n');
     expect(counts[0]?.file).toBe('a.txt');
 
     server.close();
@@ -56,11 +56,11 @@ describe('server e2e', () => {
 
     const base = `http://localhost:${port}`;
     const commitsHead = await fetchCommits(base);
-    expect(commitsHead[0]!.commit.message).toBe('feat: update\n');
+    expect(commitsHead[0]!.message).toBe('feat: update\n');
 
     app.set(appSettings.branch.description!, 'feature');
     const commitsFeature = await fetchCommits(base);
-    expect(commitsFeature[0]!.commit.message).toBe('init\n');
+    expect(commitsFeature[0]!.message).toBe('init\n');
 
     server.close();
   });

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -12,7 +12,7 @@ describe('client index', () => {
           json: () =>
             Promise.resolve({
               commits: [
-                { commit: { message: 'msg', committer: { timestamp: 1 } } },
+                { message: 'msg', timestamp: 1 },
               ],
             }),
         });

--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -11,8 +11,8 @@ describe('useTimelineData', () => {
 
   it('fetches commits and line counts', async () => {
     const commits = [
-      { commit: { message: 'a', committer: { timestamp: 2 } } },
-      { commit: { message: 'b', committer: { timestamp: 1 } } },
+      { message: 'a', timestamp: 2 },
+      { message: 'b', timestamp: 1 },
     ];
     const linesFirst = [{ file: 'a', lines: 1 }];
     const linesSecond = [{ file: 'a', lines: 2 }];

--- a/src/apiMiddleware.ts
+++ b/src/apiMiddleware.ts
@@ -13,10 +13,8 @@ import type {
 } from './api/types';
 
 const commitSchema = z.object({
-  commit: z.object({
-    message: z.string(),
-    committer: z.object({ timestamp: z.number() }),
-  }),
+  message: z.string(),
+  timestamp: z.number(),
 });
 
 const lineCountSchema = z.object({
@@ -74,7 +72,11 @@ apiMiddleware.get(
         dir,
         app.get(appSettings.branch.description!) as string | undefined,
       );
-      const commits = await git.log({ fs, dir, ref: branch });
+      const gitCommits = await git.log({ fs, dir, ref: branch });
+      const commits = gitCommits.map((c) => ({
+        message: c.commit.message,
+        timestamp: c.commit.committer.timestamp,
+      }));
       const parsed = commitsResponseSchema.safeParse({ commits });
       if (!parsed.success) {
         res.status(500).json({ error: 'Invalid data' });

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -17,7 +17,7 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
 
 
   const index = useMemo(() => {
-    let idx = commits.findIndex((c) => c.commit.committer.timestamp * 1000 <= timestamp);
+    let idx = commits.findIndex((c) => c.timestamp * 1000 <= timestamp);
     if (idx === -1) idx = commits.length - 1;
     return idx;
   }, [commits, timestamp]);
@@ -32,10 +32,7 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
   const containerHeight = document.getElementById('commit-log')?.clientHeight ?? 1;
   const spanMs =
     slice.length > 1
-      ?
-          (slice[0]!.commit.committer.timestamp -
-            slice[slice.length - 1]!.commit.committer.timestamp) *
-          1000
+      ? (slice[0]!.timestamp - slice[slice.length - 1]!.timestamp) * 1000
       : 1;
   const msPerPx = spanMs / Math.max(containerHeight, 1);
 
@@ -50,10 +47,8 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
     const prevCommit = index > 0 ? commits[index - 1] : null;
     const prevLi = current.previousElementSibling as HTMLLIElement | null;
     if (prevCommit && prevLi) {
-      const diffMs =
-        (prevCommit.commit.committer.timestamp - commits[index]!.commit.committer.timestamp) * 1000;
-      const ratio =
-        (timestamp - commits[index]!.commit.committer.timestamp * 1000) / diffMs;
+      const diffMs = (prevCommit.timestamp - commits[index]!.timestamp) * 1000;
+      const ratio = (timestamp - commits[index]!.timestamp * 1000) / diffMs;
       const prevCenter = prevLi.offsetTop + prevLi.offsetHeight / 2;
       const currCenter = current.offsetTop + current.offsetHeight / 2;
       nextOffset -= (prevCenter - currCenter) * ratio;
@@ -66,15 +61,12 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
     <div id="commit-log">
       <ul className="commit-list" style={{ transform: `translateY(${offset}px)` }}>
         {slice.map((c, i) => {
-          const diff =
-            i > 0
-              ? (slice[i - 1]!.commit.committer.timestamp - c.commit.committer.timestamp) * 1000
-              : 0;
+          const diff = i > 0 ? (slice[i - 1]!.timestamp - c.timestamp) * 1000 : 0;
           const marginTop = i > 0 ? `${diff / msPerPx}px` : undefined;
           const isCurrent = start + i === index;
           return (
             <li key={start + i} className={isCurrent ? 'current' : undefined} style={marginTop ? { marginTop } : undefined}>
-              {c.commit.message.split('\n')[0]}
+              {c.message.split('\n')[0]}
             </li>
           );
         })}

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -19,8 +19,8 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
       const data = await fetchCommits(baseUrl);
       setCommits(data);
       if (data.length) {
-        const s = data[data.length - 1]!.commit.committer.timestamp * 1000;
-        const e = data[0]!.commit.committer.timestamp * 1000;
+        const s = data[data.length - 1]!.timestamp * 1000;
+        const e = data[0]!.timestamp * 1000;
         setStart(s);
         setEnd(e);
       }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,10 +1,6 @@
 export interface Commit {
-  commit: {
-    message: string;
-    committer: {
-      timestamp: number;
-    };
-  };
+  message: string;
+  timestamp: number;
 }
 
 export interface LineCount {


### PR DESCRIPTION
## Summary
- simplify `Commit` type to expose only message and timestamp
- update API middleware to return concise commit data
- adjust timeline hooks and commit log component
- update tests for new commit shape

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684f7a4f1d4c832a8916b10fcc5e7407