### PR TITLE
Move rename demo script to legacy

### DIFF
--- a/legacy/rename-demo.ts
+++ b/legacy/rename-demo.ts
@@ -3,7 +3,7 @@ import { setTimeout as wait } from 'timers/promises';
 
 const [from, to] = process.argv.slice(2);
 if (!from || !to) {
-  console.error('Usage: tsx src/renameDemo.ts <from> <to>');
+  console.error('Usage: tsx legacy/rename-demo.ts <from> <to>');
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "test:playwright": "playwright test",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "rename-demo": "tsx src/renameDemo.ts"
+    "rename-demo": "tsx legacy/rename-demo.ts"
   },
   "dependencies": {
     "commander": "^14.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "src",
+    "legacy",
     "vite.config.ts",
     "playwright.config.ts",
     "playwright"


### PR DESCRIPTION
## Summary
- move `src/renameDemo.ts` to `legacy/rename-demo.ts`
- update `rename-demo` npm script
- include new folder in `tsconfig.json`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f7ba2c6a0832a9813ee078527358f