### PR TITLE
require timestamp for line counts

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -28,7 +28,8 @@ describe('server e2e', () => {
 
     const base = `http://localhost:${port}`;
     const commits = await fetchCommits(base);
-    const counts = await fetchLineCounts(undefined, base);
+    const ts = (await git.log({ fs, dir, ref: 'HEAD' }))[0]!.commit.committer.timestamp * 1000;
+    const counts = await fetchLineCounts(ts, base);
 
     expect(commits[0]!.message).toBe('init\n');
     expect(counts[0]?.file).toBe('a.txt');
@@ -80,7 +81,8 @@ describe('server e2e', () => {
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;
-    await expect(fetchLineCounts(undefined, base)).rejects.toThrow('No line counts');
+    const ts = (await git.log({ fs, dir, ref: 'HEAD' }))[0]!.commit.committer.timestamp * 1000;
+    await expect(fetchLineCounts(ts, base)).rejects.toThrow('No line counts');
 
     server.close();
   });

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -28,7 +28,7 @@ describe('lines module', () => {
     global.fetch = jest.fn().mockResolvedValue({
       json: () => Promise.resolve({ counts: [] }),
     });
-    await expect(fetchLineCounts()).rejects.toThrow('No line counts');
+    await expect(fetchLineCounts(100)).rejects.toThrow('No line counts');
   });
 
   it('renders circles', async () => {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -11,12 +11,10 @@ export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
 };
 
 export const fetchLineCounts = async (
-  timestamp?: number,
+  timestamp: number,
   baseUrl = '',
 ): Promise<LineCount[]> => {
-  const path =
-    timestamp === undefined ? '/api/lines' : `/api/lines?ts=${timestamp}`;
-  const response = await fetch(`${baseUrl}${path}`);
+  const response = await fetch(`${baseUrl}/api/lines?ts=${timestamp}`);
   const result = (await response.json()) as LineCountsResponse | ApiError;
   if ('counts' in result && result.counts.length > 0) {
     return result.counts;


### PR DESCRIPTION
## Summary
- make timestamp required for line count API
- update fetch helper and tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f7d33cff4832aa30bbe113b618fba