### PR TITLE
Add commit Suspense

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,46 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { CommitLog } from './components/CommitLog';
 import { SeekBar } from './components/SeekBar';
 import { FileCircleSimulation } from './components/FileCircleSimulation';
 import { useTimelineData } from './hooks';
 
-export function App(): React.JSX.Element {
+function AppContent(): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
-
-  const { commits, lineCounts, start, end, ready } = useTimelineData({
-    timestamp,
-  });
+  const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
 
   useEffect(() => {
-    if (ready) setTimestamp(start);
-  }, [ready, start]);
-
-
-
+    setTimestamp(start);
+  }, [start]);
 
   return (
     <>
-      {ready && (
-        <div id="controls">
-          <SeekBar
-            value={timestamp}
-            min={start}
-            max={end}
-            onChange={setTimestamp}
-          />
-        </div>
-      )}
+      <div id="controls">
+        <SeekBar
+          value={timestamp}
+          min={start}
+          max={end}
+          onChange={setTimestamp}
+        />
+      </div>
       <div id="timestamp">{new Date(timestamp).toLocaleString()}</div>
-      {ready && (
-        <>
-          <FileCircleSimulation data={lineCounts} />
-          <CommitLog
-            commits={commits}
-            timestamp={timestamp}
-            onTimestampChange={setTimestamp}
-          />
-        </>
-      )}
+      <FileCircleSimulation data={lineCounts} />
+      <CommitLog
+        commits={commits}
+        timestamp={timestamp}
+        onTimestampChange={setTimestamp}
+      />
     </>
+  );
+}
+
+export function App(): React.JSX.Element {
+  return (
+    <Suspense fallback={<div>Loading commits...</div>}>
+      <AppContent />
+    </Suspense>
   );
 }

--- a/src/client/commitsResource.ts
+++ b/src/client/commitsResource.ts
@@ -1,0 +1,17 @@
+import type { Commit } from './types';
+import { fetchCommits } from './api';
+import { createResource } from './resource';
+
+const cache = new Map<string, () => Commit[]>();
+
+const key = (baseUrl?: string) => baseUrl ?? '';
+
+export const readCommits = (baseUrl?: string): Commit[] => {
+  const k = key(baseUrl);
+  let resource = cache.get(k);
+  if (!resource) {
+    resource = createResource(() => fetchCommits(baseUrl));
+    cache.set(k, resource);
+  }
+  return resource();
+};

--- a/src/client/resource.ts
+++ b/src/client/resource.ts
@@ -1,0 +1,24 @@
+export function createResource<T>(fn: () => Promise<T>): () => T {
+  let status: 'pending' | 'success' | 'error' = 'pending';
+  let result: T;
+  let error: unknown;
+  const suspender = fn().then(
+    (r) => {
+      status = 'success';
+      result = r;
+    },
+    (e) => {
+      status = 'error';
+      error = e;
+    },
+  );
+  return () => {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    if (status === 'pending') throw suspender;
+    if (status === 'error') {
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw err;
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
## Summary
- use Suspense for fetching commits
- update timeline data hook to read commits via Suspense resource
- fix tests for new loading behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f7d4580f8832a91ca02f4b38ea8e4