### PR TITLE
codex/update-api-commit-params

### DIFF
--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -4,8 +4,8 @@ import { render, waitFor } from '@testing-library/react';
 import { App } from '../client/App';
 
 const commits = [
-  { message: 'new', timestamp: 2 },
-  { message: 'old', timestamp: 1 },
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
 ];
 
 describe('App commit log', () => {
@@ -16,10 +16,10 @@ describe('App commit log', () => {
     document.body.innerHTML = '<div id="root"></div>';
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
+        if (input.endsWith('/lines')) {
+          return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
+        }
         return Promise.resolve({ json: () => Promise.resolve({ commits }) });
-      }
-      if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/commitLog.test.tsx
+++ b/src/__tests__/commitLog.test.tsx
@@ -7,8 +7,8 @@ import type { Commit } from '../client/types';
 describe('CommitLog', () => {
   it('highlights current commit on timestamp change', () => {
     const commits: Commit[] = [
-      { message: 'new', timestamp: 2 },
-      { message: 'old', timestamp: 1 },
+      { id: '1', message: 'new', timestamp: 2 },
+      { id: '2', message: 'old', timestamp: 1 },
     ];
     const { container, rerender } = render(
       <CommitLog commits={commits} timestamp={1500} visible={2} />,

--- a/src/__tests__/commits.test.ts
+++ b/src/__tests__/commits.test.ts
@@ -13,12 +13,12 @@ describe('commits module', () => {
       json: () =>
         Promise.resolve({
           commits: [
-            { message: 'msg', timestamp: 1 },
+            { id: 'abc', message: 'msg', timestamp: 1 },
           ],
         }),
     });
     await expect(fetchCommits()).resolves.toEqual([
-      { message: 'msg', timestamp: 1 },
+      { id: 'abc', message: 'msg', timestamp: 1 },
     ]);
   });
 });

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -28,8 +28,7 @@ describe('server e2e', () => {
 
     const base = `http://localhost:${port}`;
     const commits = await fetchCommits(base);
-    const ts = (await git.log({ fs, dir, ref: 'HEAD' }))[0]!.commit.committer.timestamp * 1000;
-    const counts = await fetchLineCounts(ts, base);
+    const counts = await fetchLineCounts(commits[0]!.id, base);
 
     expect(commits[0]!.message).toBe('init\n');
     expect(counts[0]?.file).toBe('a.txt');
@@ -81,8 +80,8 @@ describe('server e2e', () => {
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;
-    const ts = (await git.log({ fs, dir, ref: 'HEAD' }))[0]!.commit.committer.timestamp * 1000;
-    await expect(fetchLineCounts(ts, base)).rejects.toThrow('No line counts');
+    const commitId = (await git.log({ fs, dir, ref: 'HEAD' }))[0]!.oid;
+    await expect(fetchLineCounts(commitId, base)).rejects.toThrow('No line counts');
 
     server.close();
   });

--- a/src/__tests__/index.client.test.tsx
+++ b/src/__tests__/index.client.test.tsx
@@ -7,18 +7,18 @@ describe('client index', () => {
   const originalFetch = global.fetch;
   beforeEach(() => {
     global.fetch = jest.fn((input: RequestInfo | URL) => {
+      if (typeof input === 'string' && input.startsWith('/api/commits/1/lines')) {
+        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
+      }
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
         return Promise.resolve({
           json: () =>
             Promise.resolve({
               commits: [
-                { message: 'msg', timestamp: 1 },
+                { id: '1', message: 'msg', timestamp: 1 },
               ],
             }),
         });
-      }
-      if (typeof input === 'string' && input.startsWith('/api/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
       }
       const url =
         typeof input === 'string'

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -16,19 +16,19 @@ describe('lines module', () => {
     global.fetch = originalFetch;
   });
 
-  it('fetches line counts with timestamp', async () => {
+  it('fetches line counts', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }),
     });
-    await expect(fetchLineCounts(100)).resolves.toEqual([{ file: 'a', lines: 1 }]);
-    expect(global.fetch).toHaveBeenCalledWith('/api/lines?ts=100');
+    await expect(fetchLineCounts('abc')).resolves.toEqual([{ file: 'a', lines: 1 }]);
+    expect(global.fetch).toHaveBeenCalledWith('/api/commits/abc/lines');
   });
 
   it('throws on empty counts', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       json: () => Promise.resolve({ counts: [] }),
     });
-    await expect(fetchLineCounts(100)).rejects.toThrow('No line counts');
+    await expect(fetchLineCounts('abc')).rejects.toThrow('No line counts');
   });
 
   it('renders circles', async () => {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -11,10 +11,12 @@ export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
 };
 
 export const fetchLineCounts = async (
-  timestamp: number,
+  commitId: string,
   baseUrl = '',
+  parent?: string,
 ): Promise<LineCount[]> => {
-  const response = await fetch(`${baseUrl}/api/lines?ts=${timestamp}`);
+  const query = parent ? `?parent=${parent}` : '';
+  const response = await fetch(`${baseUrl}/api/commits/${commitId}/lines${query}`);
   const result = (await response.json()) as LineCountsResponse | ApiError;
   if ('counts' in result && result.counts.length > 0) {
     return result.counts;

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -25,8 +25,10 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
   useEffect(() => {
     const ts = timestamp === 0 ? start : timestamp;
     if (ts === 0) return;
-    void fetchLineCounts(ts, baseUrl).then(setLineCounts);
-  }, [timestamp, start, baseUrl]);
+    const commit = commits.find((c) => c.timestamp * 1000 <= ts);
+    if (!commit) return;
+    void fetchLineCounts(commit.id, baseUrl).then(setLineCounts);
+  }, [timestamp, start, baseUrl, commits]);
 
   return { commits, lineCounts, start, end };
 };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,5 @@
 export interface Commit {
+  id: string;
   message: string;
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- include commit hash in commits API
- query line counts by commit ID via `/api/commits/:commitId/lines`
- update hook logic and tests for new API

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_684f801056c8832aa94458a01679d546