### PR TITLE
Add ignore outdated API results

### DIFF
--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -65,5 +65,59 @@ describe('useTimelineData', () => {
     ).toBe(1);
     expect(calls).toHaveLength(3);
   });
+
+  it('ignores results from outdated requests', async () => {
+    const commits = [
+      { id: 'c1', message: 'a', timestamp: 2 },
+      { id: 'c2', message: 'b', timestamp: 1 },
+    ];
+    const linesFirst = [{ file: 'a', lines: 1 }];
+    const linesSecond = [{ file: 'a', lines: 2 }];
+    let resolveFirst: (() => void) | undefined;
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      if (url === '/api/commits/c2/lines') {
+        return new Promise<Response>((resolve) => {
+          resolveFirst = () => resolve({
+            json: () => Promise.resolve({ counts: linesFirst }),
+          } as unknown as Response);
+        });
+      }
+      if (url === '/api/commits/c1/lines') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ counts: linesSecond }),
+        } as unknown as Response);
+      }
+      if (url.startsWith('/api/commits')) {
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
+      }
+      return Promise.reject(new Error(`unexpected ${url}`));
+    }) as unknown as typeof fetch;
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Suspense, { fallback: 'loading' }, children);
+
+    const { result, rerender } = renderHook(
+      ({ ts }) => useTimelineData({ timestamp: ts }),
+      { initialProps: { ts: 0 }, wrapper },
+    );
+
+    await waitFor(() => expect(result.current.start).toBe(1000));
+
+    rerender({ ts: 2000 });
+    await waitFor(() => expect(result.current.lineCounts).toEqual(linesSecond));
+
+    resolveFirst?.();
+    await Promise.resolve();
+
+    expect(result.current.lineCounts).toEqual(linesSecond);
+  });
 });
 

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -27,7 +27,13 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
     if (ts === 0) return;
     const commit = commits.find((c) => c.timestamp * 1000 <= ts);
     if (!commit) return;
-    void fetchLineCounts(commit.id, baseUrl).then(setLineCounts);
+    let ignore = false;
+    void fetchLineCounts(commit.id, baseUrl).then((counts) => {
+      if (!ignore) setLineCounts(counts);
+    });
+    return () => {
+      ignore = true;
+    };
   }, [timestamp, start, baseUrl, commits]);
 
   return { commits, lineCounts, start, end };


### PR DESCRIPTION
## Summary
- ignore outdated API responses in `useTimelineData`
- test ignoring outdated requests in hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --json`

------
https://chatgpt.com/codex/tasks/task_e_684f83793580832ab36dc1c1018d1b91