### PR TITLE
feat(api): add rename mapping

### DIFF
--- a/src/__tests__/lineCounts.test.ts
+++ b/src/__tests__/lineCounts.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
-import { getLineCounts } from '../server/line-counts';
+import { getLineCounts, getRenameMap } from '../server/line-counts';
 import { defaultIgnore } from '../server/ignore-defaults';
 
 const author = { name: 'a', email: 'a@example.com' };
@@ -42,5 +42,21 @@ describe('getLineCounts', () => {
 
     const counts = await getLineCounts({ dir, ref: 'HEAD', ignore: defaultIgnore });
     expect(counts.find((c) => c.file === 'package-lock.json')).toBeUndefined();
+  });
+
+  it('detects renames', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    await git.init({ fs, dir });
+    await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+    await git.add({ fs, dir, filepath: 'a.txt' });
+    await git.commit({ fs, dir, author, message: 'init' });
+    await fs.promises.rename(path.join(dir, 'a.txt'), path.join(dir, 'b.txt'));
+    await git.remove({ fs, dir, filepath: 'a.txt' });
+    await git.add({ fs, dir, filepath: 'b.txt' });
+    await git.commit({ fs, dir, author, message: 'rename' });
+
+    const logs = await git.log({ fs, dir, ref: 'HEAD', depth: 2 });
+    const renames = await getRenameMap({ dir, ref: logs[0]!.oid, parent: logs[1]!.oid });
+    expect(renames['b.txt']).toBe('a.txt');
   });
 });

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -20,7 +20,9 @@ describe('lines module', () => {
     global.fetch = jest.fn().mockResolvedValue({
       json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }),
     });
-    await expect(fetchLineCounts('abc')).resolves.toEqual([{ file: 'a', lines: 1 }]);
+    await expect(fetchLineCounts('abc')).resolves.toEqual({
+      counts: [{ file: 'a', lines: 1 }],
+    });
     expect(global.fetch).toHaveBeenCalledWith('/api/commits/abc/lines');
   });
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -10,4 +10,5 @@ export interface CommitsResponse {
 
 export interface LineCountsResponse {
   counts: LineCount[];
+  renames?: Record<string, string> | undefined;
 }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,4 +1,4 @@
-import type { Commit, LineCount } from './types';
+import type { Commit, LineCountsResult } from './types';
 import type { ApiError, CommitsResponse, LineCountsResponse } from '../api/types';
 
 export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
@@ -14,12 +14,12 @@ export const fetchLineCounts = async (
   commitId: string,
   baseUrl = '',
   parent?: string,
-): Promise<LineCount[]> => {
+): Promise<LineCountsResult> => {
   const query = parent ? `?parent=${parent}` : '';
   const response = await fetch(`${baseUrl}/api/commits/${commitId}/lines${query}`);
   const result = (await response.json()) as LineCountsResponse | ApiError;
   if ('counts' in result && result.counts.length > 0) {
-    return result.counts;
+    return result;
   }
   const message = 'error' in result ? result.error : 'No line counts';
   throw new Error(message);

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -28,7 +28,7 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
     const commit = commits.find((c) => c.timestamp * 1000 <= ts);
     if (!commit) return;
     let ignore = false;
-    void fetchLineCounts(commit.id, baseUrl).then((counts) => {
+    void fetchLineCounts(commit.id, baseUrl).then(({ counts }) => {
       if (!ignore) setLineCounts(counts);
     });
     return () => {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -8,3 +8,8 @@ export interface LineCount {
   file: string;
   lines: number;
 }
+
+export interface LineCountsResult {
+  counts: LineCount[];
+  renames?: Record<string, string> | undefined;
+}

--- a/src/server/line-counts.ts
+++ b/src/server/line-counts.ts
@@ -38,3 +38,38 @@ export const getLineCounts = async ({
   counts.sort((a, b) => b.lines - a.lines);
   return counts;
 };
+
+export const getRenameMap = async ({
+  dir,
+  ref,
+  parent,
+  ignore = [],
+}: {
+  dir: string;
+  ref: string;
+  parent: string;
+  ignore?: string[];
+}): Promise<Record<string, string>> => {
+  const oid = await git.resolveRef({ fs, dir, ref });
+  const parentOid = await git.resolveRef({ fs, dir, ref: parent });
+  const files = await git.listFiles({ fs, dir, ref });
+  const parentFiles = await git.listFiles({ fs, dir, ref: parent });
+  const parentMap = new Map<string, string>();
+  for (const file of parentFiles) {
+    if (ignore.some((p) => minimatch(file, p))) continue;
+    const { oid: blobOid } = await git.readBlob({ fs, dir, oid: parentOid, filepath: file });
+    parentMap.set(blobOid, file);
+  }
+  const renames: Record<string, string> = {};
+  const parentSet = new Set(parentFiles);
+  for (const file of files) {
+    if (ignore.some((p) => minimatch(file, p))) continue;
+    if (parentSet.has(file)) continue;
+    const { oid: blobOid } = await git.readBlob({ fs, dir, oid, filepath: file });
+    const prev = parentMap.get(blobOid);
+    if (prev && prev !== file) {
+      renames[file] = prev;
+    }
+  }
+  return renames;
+};


### PR DESCRIPTION
## Summary
- add rename map to line counts API
- support new API in client and hooks
- detect renames on server
- test rename mapping

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684f97f9ce00832ab6710a2a7baf2ba7