### PR TITLE
Add npm audit step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
+      - run: npm audit --production
+        timeout-minutes: 5
       - run: npm run typecheck
       - run: npm run lint
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Install dependencies and start the server:
 ```bash
 npm install
 npx playwright install   # install browsers for headless tests
+npm audit --production
 npm run lint
 npm test
 npm run build            # client build with Vite


### PR DESCRIPTION
## Summary
- enforce dependency security checks in CI
- document audit command in README

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f9a3572c4832a9cc4031ab8e4a7b6