### PR TITLE
Improve outdated result handling

### DIFF
--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -119,5 +119,64 @@ describe('useTimelineData', () => {
 
     expect(result.current.lineCounts).toEqual(linesSecond);
   });
+
+  it('applies outdated results if newer than current', async () => {
+    const commits = [
+      { id: 'c1', message: 'a', timestamp: 2 },
+      { id: 'c2', message: 'b', timestamp: 1 },
+    ];
+    const linesFirst = [{ file: 'a', lines: 1 }];
+    const linesSecond = [{ file: 'a', lines: 2 }];
+    let resolveFirst: (() => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      if (url === '/api/commits/c2/lines') {
+        return new Promise<Response>((resolve) => {
+          resolveFirst = () =>
+            resolve({
+              json: () => Promise.resolve({ counts: linesFirst }),
+            } as unknown as Response);
+        });
+      }
+      if (url === '/api/commits/c1/lines') {
+        return new Promise<Response>((resolve) => {
+          resolveSecond = () =>
+            resolve({
+              json: () => Promise.resolve({ counts: linesSecond }),
+            } as unknown as Response);
+        });
+      }
+      if (url.startsWith('/api/commits')) {
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
+      }
+      return Promise.reject(new Error(`unexpected ${url}`));
+    }) as unknown as typeof fetch;
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Suspense, { fallback: 'loading' }, children);
+
+    const { result, rerender } = renderHook(
+      ({ ts }) => useTimelineData({ timestamp: ts }),
+      { initialProps: { ts: 0 }, wrapper },
+    );
+
+    await waitFor(() => expect(result.current.start).toBe(1000));
+
+    rerender({ ts: 2000 });
+
+    resolveFirst?.();
+    await waitFor(() => expect(result.current.lineCounts).toEqual(linesFirst));
+
+    resolveSecond?.();
+    await waitFor(() => expect(result.current.lineCounts).toEqual(linesSecond));
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow older API results if they are newer than the current data
- test interim update behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684f9c01d48c832a9857b2a69b4fa1b9