### PR TITLE
Create useFileCircleHandles hook

### DIFF
--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-syntax */
+// eslint-disable-next-line no-restricted-syntax
 import React, { useEffect, useId, useState, useCallback, useRef } from 'react';
 import { useBody } from '../hooks';
 import * as Physics from '../physics';
@@ -34,7 +34,9 @@ export function FileCircle({
     frictionAir: 0.002,
   });
   const containerId = useId();
+  /* eslint-disable no-restricted-syntax */
   const containerRef = useRef<HTMLDivElement>(null);
+  /* eslint-enable no-restricted-syntax */
   const [contentHandle, setContentHandle] = useState<FileCircleContentHandle | null>(null);
   const [radius, setRadius] = useState(initialRadius);
   const { startGlow, glowProps } = useGlowControl();
@@ -86,15 +88,17 @@ export function FileCircle({
   const name = dir.pop() ?? '';
 
   return (
-    <div
-      className={`file-circle ${glowProps.className}`}
-      id={containerId}
-      ref={containerRef}
-      onAnimationEnd={glowProps.onAnimationEnd}
-      style={{
-        position: 'absolute',
-        width: `${radius * 2}px`,
-        height: `${radius * 2}px`,
+    <>
+      {/* eslint-disable no-restricted-syntax */}
+      <div
+        className={`file-circle ${glowProps.className}`}
+        id={containerId}
+        ref={containerRef}
+        onAnimationEnd={glowProps.onAnimationEnd}
+        style={{
+          position: 'absolute',
+          width: `${radius * 2}px`,
+          height: `${radius * 2}px`,
         borderRadius: '50%',
         background: hidden ? 'transparent' : colorForFile(file),
         willChange: 'transform',
@@ -108,7 +112,9 @@ export function FileCircle({
         hidden={hidden}
         onReady={setContentHandle}
       />
-    </div>
+      </div>
+      {/* eslint-enable no-restricted-syntax */}
+    </>
   );
 }
 

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-restricted-syntax */
+// eslint-disable-next-line no-restricted-syntax
 import React, { useEffect, useRef, useState } from 'react';
-import { PhysicsProvider, useEngine } from '../hooks';
-import { FileCircle, type FileCircleHandle } from './FileCircle';
+import { PhysicsProvider, useEngine, useFileCircleHandles } from '../hooks';
+import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
 import { Body, Engine } from '../physics';
@@ -11,7 +11,9 @@ interface FileCircleSimulationProps {
 }
 
 export function FileCircleSimulation({ data }: FileCircleSimulationProps): React.JSX.Element {
+  /* eslint-disable no-restricted-syntax */
   const containerRef = useRef<HTMLDivElement>(null);
+  /* eslint-enable no-restricted-syntax */
   const [bounds, setBounds] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
@@ -25,6 +27,7 @@ export function FileCircleSimulation({ data }: FileCircleSimulationProps): React
   }, []);
 
   return (
+    // eslint-disable-next-line no-restricted-syntax
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
       {bounds.width > 0 && (
         <PhysicsProvider bounds={bounds}>
@@ -42,7 +45,7 @@ interface FileCircleListProps {
 
 function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Element {
   const engine = useEngine();
-  const handles = useRef<Record<string, FileCircleHandle>>({});
+  const { register, forEach, get } = useFileCircleHandles();
 
   useEffect(() => {
     let frameId = 0;
@@ -50,7 +53,7 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
     const step = (time: number): void => {
       Engine.update(engine, time - last);
       last = time;
-      Object.values(handles.current).forEach((h) => {
+      forEach((h) => {
         const { x, y } = h.body.position;
         const r = h.radius;
         if (
@@ -70,7 +73,7 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
     };
     frameId = requestAnimationFrame(step);
     return () => cancelAnimationFrame(frameId);
-  }, [engine, bounds.width, bounds.height]);
+  }, [engine, bounds.width, bounds.height, forEach]);
 
   useEffect(() => {
     engine.bounds.width = bounds.width;
@@ -81,14 +84,14 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
 
   useEffect(() => {
     data.forEach((d) => {
-      const handle = handles.current[d.file];
+      const handle = get(d.file);
       if (handle) {
         const r = (Math.pow(d.lines, 0.5) * scale) / 2;
         handle.updateRadius(r);
         handle.setCount(d.lines);
       }
     });
-  }, [data, scale]);
+  }, [data, scale, get]);
 
   return (
     <>
@@ -101,7 +104,7 @@ function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Elemen
             lines={d.lines}
             initialRadius={r}
             onReady={(h) => {
-              handles.current[d.file] = h;
+              register(d.file, h);
             }}
           />
         );

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -132,3 +132,4 @@ export { usePageVisibility } from './usePageVisibility';
 export { PhysicsProvider, useEngine } from './useEngine';
 export { useBody } from './useBody';
 export { useTimelineData } from './useTimelineData';
+export { useFileCircleHandles } from './useFileCircleHandles';

--- a/src/client/hooks/useFileCircleHandles.ts
+++ b/src/client/hooks/useFileCircleHandles.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line no-restricted-syntax
+import { useCallback, useRef } from 'react';
+import type { FileCircleHandle } from '../components/FileCircle';
+
+export const useFileCircleHandles = () => {
+  /* eslint-disable no-restricted-syntax */
+  const handlesRef = useRef<Record<string, FileCircleHandle>>({});
+  /* eslint-enable no-restricted-syntax */
+
+  const register = useCallback(
+    (file: string, handle: FileCircleHandle) => {
+      handlesRef.current[file] = handle;
+    },
+    [],
+  );
+
+  const forEach = useCallback(
+    (fn: (handle: FileCircleHandle) => void) => {
+      Object.values(handlesRef.current).forEach(fn);
+    },
+    [],
+  );
+
+  const get = useCallback((file: string) => handlesRef.current[file], []);
+
+  return { register, forEach, get } as const;
+};


### PR DESCRIPTION
## Summary
- move file circle refs into new `useFileCircleHandles`
- reduce `no-restricted-syntax` disable scope around refs
- use the new hook in `FileCircleSimulation`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fa0b73b70832aa184bd79d742fcda