### PR TITLE
feat: update line counts immediatelly

### DIFF
--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -67,7 +67,7 @@ describe('useTimelineData', () => {
     expect(calls).toHaveLength(3);
   });
 
-  it('queues requests while one is in flight', async () => {
+  it('ignores outdated responses', async () => {
     const commits = [
       { id: 'c1', message: 'a', timestamp: 2 },
       { id: 'c2', message: 'b', timestamp: 1 },
@@ -115,7 +115,7 @@ describe('useTimelineData', () => {
 
     rerender({ ts: 2000 });
 
-    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(3);
 
     resolveFirst?.();
 


### PR DESCRIPTION
## Summary
- remove request queue in `useTimelineData`
- update test for ignoring outdated responses

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fa123a4ec832ab8eab9b9d2b0a8a4