### PR TITLE
Add subtle gradient to FileCircle

### DIFF
--- a/src/__tests__/colorForFile.test.ts
+++ b/src/__tests__/colorForFile.test.ts
@@ -1,4 +1,4 @@
-import { colorForFile } from '../client/colors';
+import { colorForFile, lightenColor } from '../client/colors';
 
 describe('colorForFile', () => {
   it('handles extension case-insensitively', () => {
@@ -8,5 +8,9 @@ describe('colorForFile', () => {
 
   it('handles files without extension', () => {
     expect(colorForFile('Makefile')).toBe('hsl(8,60%,60%)');
+  });
+
+  it('lightens HSL colors', () => {
+    expect(lightenColor('hsl(0,0%,50%)', 10)).toBe('hsl(0,0%,60%)');
   });
 });

--- a/src/client/colors.ts
+++ b/src/client/colors.ts
@@ -40,6 +40,22 @@ const hexToHsl = (
 const hsl = ({ h, s, l }: { h: number; s: number; l: number }): string =>
   `hsl(${h},${s}%,${l}%)`;
 
+const parseHsl = (
+  color: string,
+): { h: number; s: number; l: number } | null => {
+  const match = color.match(/^hsl\(([-\d.]+),\s*([-\d.]+)%?,\s*([-\d.]+)%?\)$/);
+  if (!match) return null;
+  const [, h, s, l] = match;
+  return { h: parseFloat(h!), s: parseFloat(s!), l: parseFloat(l!) };
+};
+
+export const lightenColor = (color: string, amount: number): string => {
+  const hslVal = parseHsl(color);
+  if (!hslVal) return color;
+  const l = Math.min(100, hslVal.l + amount);
+  return hsl({ ...hslVal, l });
+};
+
 export const colorForFile = (name: string): string => {
   const i = name.lastIndexOf('.');
   const ext = i >= 0 ? name.slice(i).toLowerCase() : '';

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useId, useState, useCallback, useRef } from 'react';
 import { useBody } from '../hooks';
 import * as Physics from '../physics';
 import { FileCircleContent, type FileCircleContentHandle } from './FileCircleContent';
-import { colorForFile } from '../colors';
+import { colorForFile, lightenColor } from '../colors';
 import { useGlowControl } from '../hooks';
 
 export interface FileCircleHandle extends FileCircleContentHandle {
@@ -84,6 +84,8 @@ export function FileCircle({
 
   const dir = file.split('/');
   const name = dir.pop() ?? '';
+  const baseColor = colorForFile(file);
+  const gradColor = lightenColor(baseColor, 15);
 
   return (
     <div
@@ -96,7 +98,9 @@ export function FileCircle({
         width: `${radius * 2}px`,
         height: `${radius * 2}px`,
         borderRadius: '50%',
-        background: hidden ? 'transparent' : colorForFile(file),
+        background: hidden
+          ? 'transparent'
+          : `radial-gradient(circle at 30% 30%, ${gradColor}, ${baseColor})`,
         willChange: 'transform',
         transform: `translate3d(${body.position.x - radius}px, ${body.position.y - radius}px, 0) rotate(${body.angle}rad)`,
       }}


### PR DESCRIPTION
## Summary
- enhance file-circle visuals with radial gradient
- expose `lightenColor` helper
- cover new color helper with unit test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_684fa168eb00832a933ee274e0591387