### PR TITLE
Add typewriter animation to file labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,18 @@
         animation: scatter 1.5s forwards;
         color: #f00;
       }
+      .typewriter::after {
+        content: '';
+        display: inline-block;
+        width: 1ch;
+        background: currentColor;
+        margin-left: 2px;
+        animation: blink 1s step-end infinite;
+      }
+      @keyframes blink {
+        from, to { opacity: 1; }
+        50% { opacity: 0; }
+      }
     </style>
   </head>
   <body>

--- a/src/__tests__/useTypewriter.test.tsx
+++ b/src/__tests__/useTypewriter.test.tsx
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useTypewriter } from '../client/hooks/useTypewriter';
+
+describe('useTypewriter', () => {
+  it('reveals text over time', () => {
+    jest.useFakeTimers();
+    const { result, rerender } = renderHook(({ text }) => useTypewriter(text), {
+      initialProps: { text: 'abc' },
+    });
+
+    expect(result.current).toBe('');
+
+    act(() => {
+      jest.advanceTimersByTime(40);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      jest.advanceTimersByTime(80);
+    });
+    expect(result.current).toBe('abc');
+
+    act(() => rerender({ text: 'de' }));
+    expect(result.current).toBe('');
+
+    act(() => {
+      jest.advanceTimersByTime(80);
+    });
+    expect(result.current).toBe('de');
+  });
+});

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useId, useState } from 'react';
-import { useCharEffects } from '../hooks';
+import { useCharEffects, useTypewriter } from '../hooks';
 
 export interface FileCircleContentHandle {
   setCount: (n: number) => void;
@@ -27,6 +27,8 @@ export function FileCircleContent({
   onReady,
 }: FileCircleContentProps): React.JSX.Element {
   const [currentCount, setCurrentCount] = useState(count);
+  const typedPath = useTypewriter(path);
+  const typedName = useTypewriter(name);
   const charsId = useId();
   const { chars, spawnChar, removeChar } = useCharEffects();
 
@@ -41,8 +43,8 @@ export function FileCircleContent({
 
   return (
     <>
-      <div className="path" style={{ display: hidden ? 'none' : undefined }}>{path}</div>
-      <div className="name" style={{ display: hidden ? 'none' : undefined }}>{name}</div>
+      <div className="path typewriter" style={{ display: hidden ? 'none' : undefined }}>{typedPath}</div>
+      <div className="name typewriter" style={{ display: hidden ? 'none' : undefined }}>{typedName}</div>
       <div className="count" style={{ display: hidden ? 'none' : undefined }}>{currentCount}</div>
       <div className="chars" id={charsId}>
         {chars.map((c) => (

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -132,3 +132,4 @@ export { usePageVisibility } from './usePageVisibility';
 export { PhysicsProvider, useEngine } from './useEngine';
 export { useBody } from './useBody';
 export { useTimelineData } from './useTimelineData';
+export { useTypewriter } from './useTypewriter';

--- a/src/client/hooks/useTypewriter.ts
+++ b/src/client/hooks/useTypewriter.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export const useTypewriter = (
+  text: string,
+  speed = 40,
+): string => {
+  const [display, setDisplay] = useState('');
+
+  useEffect(() => {
+    setDisplay('');
+    let i = 0;
+    const id = setInterval(() => {
+      i += 1;
+      setDisplay(text.slice(0, i));
+      if (i >= text.length) {
+        clearInterval(id);
+      }
+    }, speed);
+    return () => clearInterval(id);
+  }, [text, speed]);
+
+  return display;
+};
+


### PR DESCRIPTION
## Summary
- implement `useTypewriter` hook
- animate path and filename with typewriter effect
- export new hook
- test the typewriter hook
- style the typewriter with a blinking caret

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fa1bb8f08832a9e65bba466c93e76