### PR TITLE
Add animated file path display

### DIFF
--- a/src/__tests__/FilePathDisplay.test.tsx
+++ b/src/__tests__/FilePathDisplay.test.tsx
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { FilePathDisplay } from '../client/components/FilePathDisplay';
+
+describe('FilePathDisplay', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('types new text on change', () => {
+    const { container, rerender } = render(<FilePathDisplay path="a/" name="b" />);
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(container.textContent).toBe('a/b');
+
+    act(() => {
+      rerender(<FilePathDisplay path="c/" name="d" />);
+    });
+    expect(container.textContent).toBe('');
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(container.textContent).toBe('c/d');
+  });
+});

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useId, useState } from 'react';
 import { useCharEffects } from '../hooks';
+import { FilePathDisplay } from './FilePathDisplay';
 
 export interface FileCircleContentHandle {
   setCount: (n: number) => void;
@@ -41,8 +42,7 @@ export function FileCircleContent({
 
   return (
     <>
-      <div className="path" style={{ display: hidden ? 'none' : undefined }}>{path}</div>
-      <div className="name" style={{ display: hidden ? 'none' : undefined }}>{name}</div>
+      <FilePathDisplay path={path} name={name} {...(hidden === undefined ? {} : { hidden })} />
       <div className="count" style={{ display: hidden ? 'none' : undefined }}>{currentCount}</div>
       <div className="chars" id={charsId}>
         {chars.map((c) => (

--- a/src/client/components/FilePathDisplay.tsx
+++ b/src/client/components/FilePathDisplay.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTypewriter } from '../hooks';
+
+export interface FilePathDisplayProps {
+  path: string;
+  name: string;
+  hidden?: boolean;
+}
+
+export function FilePathDisplay({
+  path,
+  name,
+  hidden,
+}: FilePathDisplayProps): React.JSX.Element {
+  const pathText = useTypewriter(path);
+  const nameText = useTypewriter(name);
+
+  return (
+    <>
+      <div className="path" style={{ display: hidden ? 'none' : undefined }}>{pathText}</div>
+      <div className="name" style={{ display: hidden ? 'none' : undefined }}>{nameText}</div>
+    </>
+  );
+}

--- a/src/client/hooks/index.ts
+++ b/src/client/hooks/index.ts
@@ -128,6 +128,7 @@ export { useCssAnimation, makeUseCssAnimation } from './useCssAnimation';
 export { useGlowAnimation } from './useGlowAnimation';
 export { useGlowControl } from './useGlowControl';
 export { useCharEffects } from './useCharEffects';
+export { useTypewriter } from './useTypewriter';
 export { usePageVisibility } from './usePageVisibility';
 export { PhysicsProvider, useEngine } from './useEngine';
 export { useBody } from './useBody';

--- a/src/client/hooks/useTypewriter.ts
+++ b/src/client/hooks/useTypewriter.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export const useTypewriter = (text: string, msPerChar = 40): string => {
+  const [value, setValue] = useState(text);
+
+  useEffect(() => {
+    let i = 0;
+    setValue('');
+    const id = setInterval(() => {
+      i += 1;
+      setValue(text.slice(0, i));
+      if (i >= text.length) {
+        clearInterval(id);
+      }
+    }, msPerChar);
+    return () => clearInterval(id);
+  }, [text, msPerChar]);
+
+  return value;
+};


### PR DESCRIPTION
## Summary
- extract file path/name label into `FilePathDisplay` component
- animate label updates with new `useTypewriter` hook
- export `useTypewriter` from hooks index
- test typewriter behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fa35998c0832a9d096f6f2d508925