### PR TITLE
preserve physics state on rerender

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -66,6 +66,44 @@ describe('lines module', () => {
     stop();
   });
 
+  it('updates existing simulation when called again', async () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    const callbacks: FrameRequestCallback[] = [];
+    const raf = (cb: FrameRequestCallback): number => {
+      callbacks.push(cb);
+      return 1;
+    };
+    let stop!: () => void;
+    await act(() => {
+      stop = renderFileSimulation(div, [{ file: 'a', lines: 1 }], {
+        raf,
+        now: () => 0,
+      });
+      return Promise.resolve();
+    });
+    callbacks[0]?.(0);
+    const first = div.querySelector('.file-circle');
+    await act(() => {
+      renderFileSimulation(div, [{ file: 'a', lines: 2 }], { raf, now: () => 0 });
+      return Promise.resolve();
+    });
+    callbacks[1]?.(0);
+    const second = div.querySelector('.file-circle');
+    expect(first).toBe(second);
+    stop();
+  });
+
   it('reuses elements with same file name', async () => {
     const div = document.createElement('div');
     div.getBoundingClientRect = () => ({

--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -273,8 +273,16 @@ export const renderFileSimulation = (
     linear?: boolean;
   } = {},
 ): (() => void) => {
-  container.innerHTML = '';
-  const sim = createFileSimulation(container, opts);
+  const key = Symbol.for('blobloom.renderFileSimulation');
+  let sim = (container as unknown as Record<symbol, ReturnType<typeof createFileSimulation> | undefined>)[key];
+  if (!sim) {
+    container.innerHTML = '';
+    sim = createFileSimulation(container, opts);
+    (container as unknown as Record<symbol, ReturnType<typeof createFileSimulation>>)[key] = sim;
+  }
   sim.update(data);
-  return sim.destroy;
+  return () => {
+    sim?.destroy();
+    delete (container as unknown as Record<symbol, unknown>)[key];
+  };
 };


### PR DESCRIPTION
## Summary
- keep existing simulation when `renderFileSimulation` is called again
- test that simulation updates without recreating DOM

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_684fa89db12c832a81e14dc49e389d28