### PR TITLE
Implement easing for count animation

### DIFF
--- a/src/__tests__/useCountAnimation.test.tsx
+++ b/src/__tests__/useCountAnimation.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useCountAnimation } from '../client/hooks/useCountAnimation';
+
+jest.useFakeTimers();
+
+describe('useCountAnimation', () => {
+  const originalRaf = global.requestAnimationFrame;
+  let now = 0;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    global.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      return setTimeout(() => {
+        now += 50;
+        cb(now);
+      }, 0) as unknown as number;
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    (performance.now as jest.Mock).mockRestore();
+    global.requestAnimationFrame = originalRaf;
+  });
+
+  it('eases to the target within duration', () => {
+    const { result } = renderHook(() => useCountAnimation(0, 100));
+
+    act(() => {
+      result.current[1](100);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(result.current[0]).toBeGreaterThan(50);
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    expect(result.current[0]).toBe(100);
+  });
+});

--- a/src/client/hooks/useCountAnimation.ts
+++ b/src/client/hooks/useCountAnimation.ts
@@ -15,10 +15,12 @@ export const useCountAnimation = (
 
   const step = useCallback(
     (time: number) => {
-      const progress = Math.min(1, (time - startRef.current) / duration);
-      const next = fromRef.current + (targetRef.current - fromRef.current) * progress;
+      const linear = Math.min(1, (time - startRef.current) / duration);
+      const progress = 1 - (1 - linear) ** 2;
+      const next =
+        fromRef.current + (targetRef.current - fromRef.current) * progress;
       setValue(Math.round(next));
-      if (progress < 1) {
+      if (linear < 1) {
         frameRef.current = requestAnimationFrame(step);
       } else {
         fromRef.current = targetRef.current;


### PR DESCRIPTION
## Summary
- add quadratic easing to count animation steps
- test easing behavior in useCountAnimation hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_684fab58d8e4832a80a60e14aa394d62