### PR TITLE
feat(physics): add engine runner hook

### DIFF
--- a/src/client/hooks/useEngineRunner.tsx
+++ b/src/client/hooks/useEngineRunner.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { Engine } from '../physics';
+import { useEngine } from './useEngine';
+
+export interface EngineRunnerOptions {
+  raf?: (cb: FrameRequestCallback) => number;
+  now?: () => number;
+}
+
+export const useEngineRunner = (
+  { raf = requestAnimationFrame, now = performance.now.bind(performance) }: EngineRunnerOptions = {},
+): void => {
+  const engine = useEngine();
+  useEffect(() => {
+    let frame = 0;
+    let last = now();
+    const step = (time: number): void => {
+      Engine.update(engine, time - last);
+      last = time;
+      frame = raf(step);
+    };
+    frame = raf(step);
+    return () => cancelAnimationFrame(frame);
+  }, [engine, raf, now]);
+};
+
+export interface PhysicsRunnerProps extends EngineRunnerOptions {
+  children: React.ReactNode;
+}
+
+export const PhysicsRunner = ({ children, ...opts }: PhysicsRunnerProps): React.JSX.Element => {
+  useEngineRunner(opts);
+  return <>{children}</>;
+};


### PR DESCRIPTION
## Summary
- allow physics engine stepping independent of DOM updates
- wrap `FileCircleSimulation` with `PhysicsRunner`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684faeb2338c832aa5adee49fdf66582