### PR TITLE
feat(physics): add body update callbacks

### DIFF
--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -28,10 +28,13 @@ export function FileCircle({
   initialRadius,
   onReady,
 }: FileCircleProps): React.JSX.Element {
+  const [, setTick] = useState(0);
+  const forceUpdate = useCallback(() => setTick((t) => t + 1), []);
   const { body, setRadius: setBodyRadius } = useBody({
     radius: initialRadius,
     restitution: 0.9,
     frictionAir: 0.001,
+    onUpdate: forceUpdate,
   });
   const containerId = useId();
   /* eslint-disable no-restricted-syntax */

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -49,35 +49,10 @@ interface FileCircleListProps {
 
 function FileCircleList({ data, bounds }: FileCircleListProps): React.JSX.Element {
   const engine = useEngine();
-  const { register, forEach, get } = useFileCircleHandles();
+  const { register, get } = useFileCircleHandles();
 
   useEngineRunner();
 
-  useEffect(() => {
-    const handleOutOfBounds = (): void => {
-      forEach((h) => {
-        const { x, y } = h.body.position;
-        const r = h.radius;
-        if (
-          x < -r ||
-          x > bounds.width + r ||
-          y > bounds.height + r ||
-          y < -bounds.height - r
-        ) {
-          h.body.setVelocity({ x: 0, y: 0 });
-          h.body.setPosition({
-            x: Math.random() * (engine.bounds.width - 2 * r) + r,
-            y: -r,
-          });
-        }
-      });
-    };
-    const id = requestAnimationFrame(function loop() {
-      handleOutOfBounds();
-      requestAnimationFrame(loop);
-    });
-    return () => cancelAnimationFrame(id);
-  }, [engine, bounds.width, bounds.height, forEach]);
 
   useEffect(() => {
     engine.bounds.width = bounds.width;


### PR DESCRIPTION
## Summary
- remove out-of-bounds handler
- trigger rerenders through physics update callbacks
- keep engine updates internal to physics module

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_684fb597e600832a9ccecca4e8ce7189