### PR TITLE
Limit React physics interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@
 - Make these checks part of the regular workflow and account for them when updating CI.
 * Use React refs only when absolutely necessary and preferably within custom hooks.
   Override the ESLint ref restriction locally in such files or lines.
+* React components must not modify physics engine state directly except for:
+  - Adjusting engine bounds via `PhysicsProvider`
+  - Creating or removing bodies through hooks
+  - Changing body radius via `useBody`
 
 ## TODO
 - Add more hook tests and restore coverage threshold to 80.

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -24,13 +24,6 @@ export function FileCircle({
   });
   const [currentRadius, setCurrentRadius] = useState(radius);
   useEffect(() => {
-    body.setPosition({
-      x: body.position.x,
-      y: -Math.random() * (window.innerHeight || 0) - radius,
-    });
-  }, [body, radius]);
-
-  useEffect(() => {
     if (radius === currentRadius) return;
     body.scale(radius / currentRadius, radius / currentRadius);
     setBodyRadius(radius);


### PR DESCRIPTION
## Summary
- remove direct body position reset in `FileCircle`
- document restrictions on manipulating physics state from React

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fd26ad21c832aa95327f1a2845ffc