### PR TITLE
Add play/pause button

### DIFF
--- a/src/__tests__/appPlayPause.test.tsx
+++ b/src/__tests__/appPlayPause.test.tsx
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor, act, fireEvent } from '@testing-library/react';
+import { App } from '../client/App';
+
+const commits = [
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
+];
+
+describe('App play/pause', () => {
+  const originalFetch = global.fetch;
+  const originalRaf = global.requestAnimationFrame;
+  let now = 0;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      if (typeof input === 'string' && input.startsWith('/api/commits')) {
+        if (input.endsWith('/lines')) {
+          return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
+      }
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
+    }) as jest.Mock;
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    global.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      return setTimeout(() => {
+        now += 50;
+        cb(now);
+      }, 0) as unknown as number;
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    (performance.now as jest.Mock).mockRestore();
+    global.fetch = originalFetch;
+    global.requestAnimationFrame = originalRaf;
+  });
+
+  it('pauses and resumes playback when toggled', async () => {
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
+
+    const input = container.querySelector('input[type="range"]') as HTMLInputElement;
+    const button = container.querySelector('#controls button') as HTMLButtonElement;
+    const initial = Number(input.value);
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    await waitFor(() => expect(Number(input.value)).toBeGreaterThan(initial));
+
+    fireEvent.click(button); // pause
+    const pausedValue = Number(input.value);
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(Number(input.value)).toBe(pausedValue);
+
+    fireEvent.click(button); // resume
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    await waitFor(() => expect(Number(input.value)).toBeGreaterThan(pausedValue));
+  });
+});

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect, useState } from 'react';
 import { CommitLog } from './components/CommitLog';
 import { SeekBar } from './components/SeekBar';
+import { PlayPauseButton } from './components/PlayPauseButton';
 import { FileCircleSimulation } from './components/FileCircleSimulation';
 import { useTimelineData } from './hooks/useTimelineData';
 import { usePlayer } from './hooks/usePlayer';
@@ -10,13 +11,15 @@ const PLAY_DURATION = 30;
 function AppContent(): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
   const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
+  const [playing, setPlaying] = useState(false);
 
-  const { resume } = usePlayer({
+  const { resume, togglePlay } = usePlayer({
     getSeek: () => timestamp,
     setSeek: setTimestamp,
     duration: PLAY_DURATION,
     start,
     end,
+    onPlayStateChange: setPlaying,
   });
 
   useEffect(() => {
@@ -29,6 +32,7 @@ function AppContent(): React.JSX.Element {
   return (
     <>
       <div id="controls">
+        <PlayPauseButton playing={playing} onToggle={togglePlay} />
         <SeekBar
           value={timestamp}
           min={start}

--- a/src/client/components/PlayPauseButton.tsx
+++ b/src/client/components/PlayPauseButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export interface PlayPauseButtonProps {
+  playing: boolean;
+  onToggle: () => void;
+}
+
+export function PlayPauseButton({ playing, onToggle }: PlayPauseButtonProps): React.JSX.Element {
+  return (
+    <button type="button" onClick={onToggle}>
+      {playing ? 'Pause' : 'Play'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `PlayPauseButton` component
- show play/pause control in `App`
- test play/pause interactions

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fd45b1338832aaae8f04d62a9e886