### PR TITLE
Change scaling area to square

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -198,7 +198,7 @@ describe('lines module', () => {
 
   it('returns eased scale when ratio exceeds threshold', () => {
     const scale = computeScale(1000, 200, [{ file: 'a', lines: 1 }]);
-    expect(scale).toBeCloseTo(197.7, 1);
+    expect(scale).toBeCloseTo(186.1, 1);
   });
 
   it('returns 0 when area is zero', () => {

--- a/src/client/scale.ts
+++ b/src/client/scale.ts
@@ -16,7 +16,8 @@ export const computeScale = (
   const totalArea = data.reduce(
     (sum, f) => {
       const lines = Number.isFinite(f.lines) ? f.lines : 0;
-      return sum + Math.PI * ((Math.pow(lines, exp) * base) / 2) ** 2;
+      const r = (Math.pow(lines, exp) * base) / 2;
+      return sum + 4 * r ** 2;
     },
     0,
   );


### PR DESCRIPTION
## Summary
- update `computeScale` to use square area for easing ratio
- align tests with new area scaling logic

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fd50a7a5c832a9123d0b91550f32e