### PR TITLE
Adjust physics delta and gravity

### DIFF
--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -25,7 +25,7 @@ export const createFileSimulation = (
   let height = rect.height;
   const engine = Engine.create(width, height);
   engine.gravity.y = 1;
-  engine.gravity.scale = 0.001;
+  engine.gravity.scale = 0.002;
 
   const root = createRoot(container);
   let currentData: LineCount[] = [];

--- a/src/client/physics.ts
+++ b/src/client/physics.ts
@@ -76,8 +76,9 @@ export class Body {
 
 export class Engine {
   world: { bodies: Body[] };
-  gravity = { y: 1, scale: 0.001 };
+  gravity = { y: 1, scale: 0.002 };
   bounds: { width: number; height: number };
+  maxDelta = 50;
   private runner?: EngineRunner;
 
   constructor(width = 0, height = 0) {
@@ -146,12 +147,13 @@ export class Engine {
   }
 
   update(delta: number) {
+    const dt = Math.min(delta, this.maxDelta);
     const g = this.gravity.y * this.gravity.scale;
     const { width, height } = this.bounds;
     const bodies = this.world.bodies;
     for (const body of bodies) {
       if (body.isStatic) continue;
-      body.velocity.y += g * delta;
+      body.velocity.y += g * dt;
       body.velocity.x *= 1 - body.frictionAir;
       body.velocity.y *= 1 - body.frictionAir;
       body.angularVelocity *= 1 - body.frictionAir;


### PR DESCRIPTION
## Summary
- bump `gravity.scale` from 0.001 to 0.002 so objects fall faster
- clip large frame deltas in `Engine.update`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fd64bc178832ab9d58b0fcfb18112