### PR TITLE
Add playback duration control

### DIFF
--- a/src/__tests__/appDurationControl.test.tsx
+++ b/src/__tests__/appDurationControl.test.tsx
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import { App } from '../client/App';
+import { createPlayer } from '../client/player';
+
+jest.mock('../client/player');
+
+const commits = [
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
+];
+
+describe('App duration control', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+    (createPlayer as jest.Mock).mockReturnValue({
+      stop: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      togglePlay: jest.fn(),
+      isPlaying: jest.fn(() => false),
+    });
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      if (typeof input === 'string' && input.startsWith('/api/commits')) {
+        if (input.endsWith('/lines')) {
+          return Promise.resolve({
+            json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }),
+          });
+        }
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
+      }
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('recreates player with new duration', async () => {
+    const { container } = render(<App />);
+    await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
+
+    const input = container.querySelector('#duration') as HTMLInputElement;
+    expect(input.value).toBe('30');
+
+    fireEvent.change(input, { target: { value: '10' } });
+
+    await waitFor(() => {
+      const mock = createPlayer as jest.MockedFunction<typeof createPlayer>;
+      const last = mock.mock.calls[mock.mock.calls.length - 1] as unknown as [
+        Record<string, unknown>,
+      ];
+      expect(last[0]).toEqual(expect.objectContaining({ duration: 10 }));
+    });
+  });
+});

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -6,17 +6,18 @@ import { FileCircleSimulation } from './components/FileCircleSimulation';
 import { useTimelineData } from './hooks/useTimelineData';
 import { usePlayer } from './hooks/usePlayer';
 
-const PLAY_DURATION = 30;
+const DEFAULT_DURATION = 30;
 
 function AppContent(): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
+  const [duration, setDuration] = useState(DEFAULT_DURATION);
   const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
   const [playing, setPlaying] = useState(false);
 
   const { resume, togglePlay } = usePlayer({
     getSeek: () => timestamp,
     setSeek: setTimestamp,
-    duration: PLAY_DURATION,
+    duration,
     start,
     end,
     onPlayStateChange: setPlaying,
@@ -33,20 +34,21 @@ function AppContent(): React.JSX.Element {
     <>
       <div id="controls">
         <PlayPauseButton playing={playing} onToggle={togglePlay} />
-        <SeekBar
-          value={timestamp}
-          min={start}
-          max={end}
-          onChange={setTimestamp}
-        />
+        <SeekBar value={timestamp} min={start} max={end} onChange={setTimestamp} />
+        <label>
+          Duration
+          <input
+            id="duration"
+            type="number"
+            min="1"
+            value={duration}
+            onChange={e => setDuration(Number((e.target as HTMLInputElement).value))}
+          />
+        </label>
       </div>
       <div id="timestamp">{new Date(timestamp).toLocaleString()}</div>
       <FileCircleSimulation data={lineCounts} />
-      <CommitLog
-        commits={commits}
-        timestamp={timestamp}
-        onTimestampChange={setTimestamp}
-      />
+      <CommitLog commits={commits} timestamp={timestamp} onTimestampChange={setTimestamp} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add duration input to `App` for customizing playback length
- recreate player when duration changes
- test duration control updates `createPlayer`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`

------
https://chatgpt.com/codex/tasks/task_e_684fddd6b06c832aa711d866c81f479d