### PR TITLE
Add added/removed counts to lineCounts API

### DIFF
--- a/src/__tests__/SimulationArea.test.tsx
+++ b/src/__tests__/SimulationArea.test.tsx
@@ -12,7 +12,7 @@ const update = jest.fn();
   update,
 });
 
-const data: LineCount[] = [{ file: 'a', lines: 1 }];
+const data: LineCount[] = [{ file: 'a', lines: 1, added: 0, removed: 0 }];
 
 describe('SimulationArea', () => {
   beforeEach(() => {

--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -17,7 +17,10 @@ describe('App commit log', () => {
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
         if (input.endsWith('/lines')) {
-          return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
+          return Promise.resolve({
+            json: () =>
+              Promise.resolve({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }),
+          });
         }
         return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }

--- a/src/__tests__/appPlayPause.test.tsx
+++ b/src/__tests__/appPlayPause.test.tsx
@@ -20,7 +20,10 @@ describe('App play/pause', () => {
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       if (typeof input === 'string' && input.startsWith('/api/commits')) {
         if (input.endsWith('/lines')) {
-          return Promise.resolve({ json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }) });
+          return Promise.resolve({
+            json: () =>
+              Promise.resolve({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }),
+          });
         }
         return Promise.resolve({ json: () => Promise.resolve({ commits }) });
       }

--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -18,10 +18,11 @@ describe('lines module', () => {
 
   it('fetches line counts', async () => {
     global.fetch = jest.fn().mockResolvedValue({
-      json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }),
+      json: () =>
+        Promise.resolve({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }),
     });
     await expect(fetchLineCounts('abc')).resolves.toEqual({
-      counts: [{ file: 'a', lines: 1 }],
+      counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }],
     });
     expect(global.fetch).toHaveBeenCalledWith('/api/commits/abc/lines');
   });
@@ -48,8 +49,8 @@ describe('lines module', () => {
       toJSON: () => {},
     });
     const data: LineCount[] = [
-      { file: 'a', lines: 1 },
-      { file: 'b', lines: 2 },
+      { file: 'a', lines: 1, added: 0, removed: 0 },
+      { file: 'b', lines: 2, added: 0, removed: 0 },
     ];
     const callbacks: FrameRequestCallback[] = [];
     const raf = (cb: FrameRequestCallback): number => {
@@ -86,7 +87,7 @@ describe('lines module', () => {
     };
     let stop!: () => void;
     await act(() => {
-      stop = renderFileSimulation(div, [{ file: 'a', lines: 1 }], {
+      stop = renderFileSimulation(div, [{ file: 'a', lines: 1, added: 0, removed: 0 }], {
         raf,
         now: () => 0,
       });
@@ -95,7 +96,10 @@ describe('lines module', () => {
     callbacks[0]?.(0);
     const first = div.querySelector('.file-circle');
     await act(() => {
-      renderFileSimulation(div, [{ file: 'a', lines: 2 }], { raf, now: () => 0 });
+      renderFileSimulation(div, [{ file: 'a', lines: 2, added: 0, removed: 0 }], {
+        raf,
+        now: () => 0,
+      });
       return Promise.resolve();
     });
     callbacks[1]?.(0);
@@ -128,14 +132,14 @@ describe('lines module', () => {
       return Promise.resolve();
     });
     await act(() => {
-      sim.update([{ file: 'a', lines: 1 }]);
+      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     await act(() => Promise.resolve());
     callbacks[0]?.(0);
     const first = div.querySelector('.file-circle');
     await act(() => {
-      sim.update([{ file: 'a', lines: 2 }]);
+      sim.update([{ file: 'a', lines: 2, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     await act(() => Promise.resolve());
@@ -170,7 +174,7 @@ describe('lines module', () => {
       return Promise.resolve();
     });
     await act(() => {
-      sim.update([{ file: 'a', lines: 1 }]);
+      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     callbacks[0]?.(0);
@@ -180,16 +184,16 @@ describe('lines module', () => {
 
   it('computes scale with easing', () => {
     const scale = computeScale(200, 200, [
-      { file: 'a', lines: 1 },
-      { file: 'b', lines: 2 },
+      { file: 'a', lines: 1, added: 0, removed: 0 },
+      { file: 'b', lines: 2, added: 0, removed: 0 },
     ]);
     expect(scale).toBeLessThan(100);
   });
 
   it('supports linear scaling option', () => {
     const data: LineCount[] = [
-      { file: 'a', lines: 1 },
-      { file: 'b', lines: 2 },
+      { file: 'a', lines: 1, added: 0, removed: 0 },
+      { file: 'b', lines: 2, added: 0, removed: 0 },
     ];
     const nonlinear = computeScale(200, 200, data);
     const linear = computeScale(200, 200, data, { linear: true });
@@ -197,12 +201,12 @@ describe('lines module', () => {
   });
 
   it('returns eased scale when ratio exceeds threshold', () => {
-    const scale = computeScale(1000, 200, [{ file: 'a', lines: 1 }]);
+    const scale = computeScale(1000, 200, [{ file: 'a', lines: 1, added: 0, removed: 0 }]);
     expect(scale).toBeCloseTo(186.1, 1);
   });
 
   it('returns 0 when area is zero', () => {
-    const scale = computeScale(0, 200, [{ file: 'a', lines: 1 }]);
+    const scale = computeScale(0, 200, [{ file: 'a', lines: 1, added: 0, removed: 0 }]);
     expect(scale).toBe(0);
   });
 
@@ -261,7 +265,7 @@ describe('lines module', () => {
       sim = createFileSimulation(div, { raf, now: () => 0 });
       return Promise.resolve();
     });
-    const data: LineCount[] = [{ file: 'a', lines: 5 }];
+    const data: LineCount[] = [{ file: 'a', lines: 5, added: 0, removed: 0 }];
     await act(() => {
       sim.update(data);
       return Promise.resolve();
@@ -303,14 +307,14 @@ describe('lines module', () => {
     });
     sim.setEffectsEnabled(false);
     await act(() => {
-      sim.update([{ file: 'a', lines: 1 }]);
+      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     expect(div.querySelector('.add-char')).toBeNull();
     expect(div.querySelector('.glow-new')).toBeNull();
     sim.setEffectsEnabled(true);
     await act(() => {
-      sim.update([{ file: 'a', lines: 2 }]);
+      sim.update([{ file: 'a', lines: 2, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     // TODO: verify character effect rendering once React flushing is reliable
@@ -333,7 +337,7 @@ describe('lines module', () => {
     const sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
     sim.setEffectsEnabled(true);
     await act(() => {
-      sim.update([{ file: 'a', lines: MAX_EFFECT_CHARS * 2 }]);
+      sim.update([{ file: 'a', lines: MAX_EFFECT_CHARS * 2, added: 0, removed: 0 }]);
       return Promise.resolve();
     });
     const chars = div.querySelectorAll('.add-char').length;

--- a/src/__tests__/useTimelineData.test.ts
+++ b/src/__tests__/useTimelineData.test.ts
@@ -15,8 +15,8 @@ describe('useTimelineData', () => {
       { id: 'c1', message: 'a', timestamp: 2 },
       { id: 'c2', message: 'b', timestamp: 1 },
     ];
-    const linesFirst = [{ file: 'a', lines: 1 }];
-    const linesSecond = [{ file: 'a', lines: 2 }];
+    const linesFirst = [{ file: 'a', lines: 1, added: 0, removed: 0 }];
+    const linesSecond = [{ file: 'a', lines: 2, added: 1, removed: 0 }];
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       const url =
         typeof input === 'string'
@@ -72,8 +72,8 @@ describe('useTimelineData', () => {
       { id: 'c1', message: 'a', timestamp: 2 },
       { id: 'c2', message: 'b', timestamp: 1 },
     ];
-    const linesFirst = [{ file: 'a', lines: 1 }];
-    const linesSecond = [{ file: 'a', lines: 2 }];
+    const linesFirst = [{ file: 'a', lines: 1, added: 0, removed: 0 }];
+    const linesSecond = [{ file: 'a', lines: 2, added: 1, removed: 0 }];
     let resolveFirst: (() => void) | undefined;
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       const url =
@@ -132,8 +132,8 @@ describe('useTimelineData', () => {
       { id: 'c1', message: 'rename', timestamp: 2 },
       { id: 'c0', message: 'init', timestamp: 1 },
     ];
-    const linesInit = [{ file: 'a.txt', lines: 1 }];
-    const linesRenamed = [{ file: 'b.txt', lines: 1 }];
+    const linesInit = [{ file: 'a.txt', lines: 1, added: 0, removed: 0 }];
+    const linesRenamed = [{ file: 'b.txt', lines: 1, added: 0, removed: 0 }];
     global.fetch = jest.fn((input: RequestInfo | URL) => {
       const url =
         typeof input === 'string'
@@ -169,7 +169,9 @@ describe('useTimelineData', () => {
 
     rerender({ ts: 2000 });
     await waitFor(() =>
-      expect(result.current.lineCounts).toEqual([{ file: 'a.txt', lines: 1 }]),
+      expect(result.current.lineCounts).toEqual([
+        { file: 'a.txt', lines: 1, added: 0, removed: 0 },
+      ]),
     );
   });
 });

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -7,6 +7,8 @@ export interface Commit {
 export interface LineCount {
   file: string;
   lines: number;
+  added: number;
+  removed: number;
 }
 
 export interface LineCountsResult {

--- a/src/server/api-middleware.ts
+++ b/src/server/api-middleware.ts
@@ -21,6 +21,8 @@ const commitSchema = z.object({
 const lineCountSchema = z.object({
   file: z.string(),
   lines: z.number(),
+  added: z.number(),
+  removed: z.number(),
 });
 
 const commitsResponseSchema = z.object({
@@ -113,7 +115,14 @@ apiMiddleware.get(
       const ignore = ignorePatterns(app);
 
       await git.resolveRef({ fs, dir, ref: req.params.commitId });
-      const counts = await getLineCounts({ dir, ref: req.params.commitId, ignore });
+      const options = { dir, ref: req.params.commitId, ignore } as {
+        dir: string;
+        ref: string;
+        ignore: string[];
+        parent?: string;
+      };
+      if (params.data.parent) options.parent = params.data.parent;
+      const counts = await getLineCounts(options);
       const renames = params.data.parent
         ? await getRenameMap({
             dir,

--- a/src/server/line-counts.ts
+++ b/src/server/line-counts.ts
@@ -13,27 +13,67 @@ const isBinary = (buf: Buffer): boolean => {
 export interface LineCount {
   file: string;
   lines: number;
+  added: number;
+  removed: number;
 }
+
+const diffCounts = (
+  a: string[],
+  b: string[],
+): { added: number; removed: number } => {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array<number>(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i]![j] = a[i - 1] === b[j - 1] ? dp[i - 1]![j - 1]! + 1 : Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+    }
+  }
+  const lcs = dp[m]![n]!;
+  return { added: n - lcs, removed: m - lcs };
+};
 
 export const getLineCounts = async ({
   dir,
   ref,
   ignore = [],
+  parent,
 }: {
   dir: string;
   ref: string;
   ignore?: string[];
+  parent?: string;
 }): Promise<LineCount[]> => {
   const oid = await git.resolveRef({ fs, dir, ref });
   const files = await git.listFiles({ fs, dir, ref });
   const counts: LineCount[] = [];
+  const parentOid = parent ? await git.resolveRef({ fs, dir, ref: parent }) : undefined;
+  const parentCache = new Map<string, string[]>();
+  if (parentOid) {
+    const parentFiles = await git.listFiles({ fs, dir, ref: parent });
+    for (const file of parentFiles) {
+      if (ignore.some((p) => minimatch(file, p))) continue;
+      const { blob } = await git.readBlob({ fs, dir, oid: parentOid, filepath: file });
+      const buf = Buffer.from(blob);
+      if (isBinary(buf)) continue;
+      parentCache.set(file, buf.toString('utf8').trimEnd().split(/\r?\n/));
+    }
+  }
   for (const file of files) {
     if (ignore.some((p) => minimatch(file, p))) continue;
     const { blob } = await git.readBlob({ fs, dir, oid, filepath: file });
     const buffer = Buffer.from(blob);
     if (isBinary(buffer)) continue;
-    const content = buffer.toString('utf8').trimEnd();
-    counts.push({ file, lines: content.split(/\r?\n/).length });
+    const lines = buffer.toString('utf8').trimEnd().split(/\r?\n/);
+    const prev = parentCache.get(file);
+    let added = 0;
+    let removed = 0;
+    if (prev) {
+      ({ added, removed } = diffCounts(prev, lines));
+    } else if (parent) {
+      added = lines.length;
+    }
+    counts.push({ file, lines: lines.length, added, removed });
   }
   counts.sort((a, b) => b.lines - a.lines);
   return counts;


### PR DESCRIPTION
## Summary
- include added and removed counts in `LineCount`
- return diff counts when fetching line stats
- pass parent commit to `getLineCounts`
- adjust tests for new fields

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fdd04e894832a8281137cf3911111