### PR TITLE
Fix char effects timing and range

### DIFF
--- a/src/__tests__/charEffectsComponent.test.tsx
+++ b/src/__tests__/charEffectsComponent.test.tsx
@@ -32,4 +32,21 @@ describe('CharEffects component', () => {
     expect(container.querySelectorAll('.add-char').length).toBe(1);
     expect(container.querySelector('.add-char')).toBeTruthy();
   });
+
+  it('removes characters after animation', () => {
+    // eslint-disable-next-line no-restricted-syntax
+    const ref = React.createRef<Ref>();
+    // eslint-disable-next-line no-restricted-syntax
+    const { container } = render(<Wrapper ref={ref} />);
+    act(() => {
+      ref.current!.spawn();
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(container.querySelector('.add-char')).toBeNull();
+  });
 });

--- a/src/client/components/CharEffects.tsx
+++ b/src/client/components/CharEffects.tsx
@@ -26,11 +26,15 @@ export function CharEffects({ effects }: CharEffectsProps): React.JSX.Element {
         );
       }
     });
-    return () => {
-      map.forEach((t) => clearTimeout(t));
-      map.clear();
-    };
   }, [chars, removeChar]);
+
+  React.useEffect(
+    () => () => {
+      timers.current.forEach((t) => clearTimeout(t));
+      timers.current.clear();
+    },
+    [],
+  );
   return (
     <div className="chars">
       <TransitionGroup component={null}>

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -58,7 +58,7 @@ export function FileCircle({
     const spawn = Math.min(Math.abs(diff), available);
     for (let i = 0; i < spawn; i += 1) {
       const angle = Math.random() * 2 * Math.PI;
-      const r = Math.sqrt(Math.random()) * currentRadius;
+      const r = Math.sqrt(Math.random()) * currentRadius * 1.5;
       const offset = { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
       spawnChar(diff > 0 ? 'add-char' : 'remove-char', offset, () => {});
     }


### PR DESCRIPTION
## Summary
- widen char effect spawn radius
- clear timeouts only on unmount
- ensure effect nodes disappear after animation
- test removal timing

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit dev`


------
https://chatgpt.com/codex/tasks/task_e_684fdf9d0cdc832ab6697704f663fc9c