### PR TITLE
codex/default-paused

### DIFF
--- a/src/__tests__/appAutoplay.test.tsx
+++ b/src/__tests__/appAutoplay.test.tsx
@@ -8,7 +8,7 @@ const commits = [
   { id: 'o', message: 'old', timestamp: 1 },
 ];
 
-describe('App autoplay', () => {
+describe('App initial pause', () => {
   const originalFetch = global.fetch;
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
@@ -50,7 +50,7 @@ describe('App autoplay', () => {
     global.requestAnimationFrame = originalRaf;
   });
 
-  it('advances timestamp automatically', async () => {
+  it('does not advance timestamp automatically', async () => {
     const { container } = render(<App />);
     await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
 
@@ -61,7 +61,7 @@ describe('App autoplay', () => {
       jest.advanceTimersByTime(100);
     });
 
-    await waitFor(() => expect(Number(input.value)).toBeGreaterThan(initial));
+    expect(Number(input.value)).toBe(initial);
   });
 });
 

--- a/src/__tests__/appPlayPause.test.tsx
+++ b/src/__tests__/appPlayPause.test.tsx
@@ -65,6 +65,13 @@ describe('App play/pause', () => {
       jest.advanceTimersByTime(100);
     });
 
+    expect(Number(input.value)).toBe(initial);
+
+    fireEvent.click(button); // play
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
     await waitFor(() => expect(Number(input.value)).toBeGreaterThan(initial));
 
     fireEvent.click(button); // pause

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,7 +14,7 @@ function AppContent(): React.JSX.Element {
   const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
   const [playing, setPlaying] = useState(false);
 
-  const { resume, togglePlay } = usePlayer({
+  const { togglePlay } = usePlayer({
     getSeek: () => timestamp,
     setSeek: setTimestamp,
     duration,
@@ -25,10 +25,7 @@ function AppContent(): React.JSX.Element {
 
   useEffect(() => {
     setTimestamp(start);
-    if (start && end) {
-      resume();
-    }
-  }, [start, end, resume]);
+  }, [start, end]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- set default state to paused
- update tests for the paused start behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_684fe2592cf4832a924fad9667cf1e56