### PR TITLE
fix text effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
         }
       }
       .add-char {
-        animation: gather 1.5s forwards;
+        animation: gather 1.5s forwards, fadeOut 0.5s forwards 1.5s;
         color: #0f0;
       }
       .remove-char {

--- a/src/__tests__/charEffectsComponent.test.tsx
+++ b/src/__tests__/charEffectsComponent.test.tsx
@@ -42,7 +42,7 @@ describe('CharEffects component', () => {
       ref.current!.spawn();
     });
     act(() => {
-      jest.advanceTimersByTime(3000);
+      jest.advanceTimersByTime(2600);
     });
     act(() => {
       jest.runAllTimers();

--- a/src/client/components/CharEffects.tsx
+++ b/src/client/components/CharEffects.tsx
@@ -22,7 +22,7 @@ export function CharEffects({ effects }: CharEffectsProps): React.JSX.Element {
           c.id,
           setTimeout(() => {
             removeChar(c.id);
-          }, Math.round((1.5 + c.delay) * 1000)),
+          }, Math.round((2 + c.delay) * 1000)),
         );
       }
     });
@@ -49,7 +49,7 @@ export function CharEffects({ effects }: CharEffectsProps): React.JSX.Element {
             <CSSTransition
               key={c.id}
               nodeRef={nodeRef}
-              timeout={Math.round((1.5 + c.delay) * 1000)}
+              timeout={Math.round((2 + c.delay) * 1000)}
             onExited={() => {
               c.onEnd();
               refs.current.delete(c.id);

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -58,7 +58,7 @@ export function FileCircle({
     const spawn = Math.min(Math.abs(diff), available);
     for (let i = 0; i < spawn; i += 1) {
       const angle = Math.random() * 2 * Math.PI;
-      const r = Math.sqrt(Math.random()) * currentRadius * 1.5;
+      const r = Math.sqrt(Math.random()) * currentRadius * 2.5;
       const offset = { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
       spawnChar(diff > 0 ? 'add-char' : 'remove-char', offset, () => {});
     }


### PR DESCRIPTION
## Summary
- expand character effect radius
- fade out green text
- adjust timers accordingly
- update char effect test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fe293f9ac832a844f0b210c3ea815