### PR TITLE
fix(glow-effect)

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -321,6 +321,39 @@ describe('lines module', () => {
     sim.destroy();
   });
 
+  it('shows glow when effects are enabled after mount', async () => {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = () => ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      bottom: 200,
+      right: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+    let sim!: ReturnType<typeof createFileSimulation>;
+    await act(() => {
+      sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
+      return Promise.resolve();
+    });
+    sim.setEffectsEnabled(false);
+    await act(() => {
+      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
+      return Promise.resolve();
+    });
+    sim.setEffectsEnabled(true);
+    await act(() => {
+      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
+      return Promise.resolve();
+    });
+    expect(div.querySelector('.glow-new')).toBeTruthy();
+    sim.destroy();
+    div.remove();
+  });
+
   it('limits active character effects', async () => {
     const div = document.createElement('div');
     div.getBoundingClientRect = () => ({

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -42,7 +42,7 @@ export function FileCircle({
     if (effectsEnabled) startGlow('glow-new');
     prevLines.current = lines;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [effectsEnabled]);
 
   useEffect(() => {
     if (!effectsEnabled) {


### PR DESCRIPTION
## Summary
- add failing test for glow effect when enabling effects
- ensure glow effect triggers when effectsEnabled becomes true

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fe44c71e4832ab26f8029903754e4