### PR TITLE
fix physics bounds

### DIFF
--- a/src/__tests__/useEngine.test.tsx
+++ b/src/__tests__/useEngine.test.tsx
@@ -13,12 +13,12 @@ describe('PhysicsProvider', () => {
 
     const { result, rerender } = renderHook(() => useEngine(), { wrapper });
 
-    expect(result.current.bounds).toEqual({ width: 50, height: 60 });
+    expect(result.current.bounds).toEqual({ width, height, top: -height });
 
     width = 80;
     height = 90;
     rerender();
 
-    expect(result.current.bounds).toEqual({ width: 80, height: 90 });
+    expect(result.current.bounds).toEqual({ width, height, top: -height });
   });
 });

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -54,6 +54,7 @@ export function FileCircleList({ data, bounds, linear, effectsEnabled = true }: 
   useEffect(() => {
     engine.bounds.width = bounds.width;
     engine.bounds.height = bounds.height;
+    engine.bounds.top = -bounds.height;
   }, [engine, bounds.width, bounds.height]);
 
   const scale = useMemo(

--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -24,6 +24,7 @@ export const createFileSimulation = (
   let width = rect.width;
   let height = rect.height;
   const engine = Engine.create(width, height);
+  engine.bounds.top = -height;
   engine.gravity.y = 1;
   engine.gravity.scale = 0.002;
 
@@ -81,6 +82,7 @@ export const createFileSimulation = (
     height = rect.height;
     engine.bounds.width = width;
     engine.bounds.height = height;
+    engine.bounds.top = -height;
     if (currentData.length) render();
   };
 

--- a/src/client/hooks/useEngine.tsx
+++ b/src/client/hooks/useEngine.tsx
@@ -23,6 +23,7 @@ export function PhysicsProvider({ bounds, engine: externalEngine, children }: Ph
   useEffect(() => {
     engine.bounds.width = bounds.width;
     engine.bounds.height = bounds.height;
+    engine.bounds.top = -bounds.height;
   }, [engine, bounds.width, bounds.height]);
 
   return <EngineContext.Provider value={engine}>{children}</EngineContext.Provider>;

--- a/src/client/physics.ts
+++ b/src/client/physics.ts
@@ -77,13 +77,13 @@ export class Body {
 export class Engine {
   world: { bodies: Body[] };
   gravity = { y: 1, scale: 0.002 };
-  bounds: { width: number; height: number };
+  bounds: { width: number; height: number; top: number };
   maxDelta = 50;
   private runner?: EngineRunner;
 
   constructor(width = 0, height = 0) {
     this.world = { bodies: [] };
-    this.bounds = { width, height };
+    this.bounds = { width, height, top: -height };
   }
 
   static create(width = 0, height = 0): Engine {
@@ -149,7 +149,7 @@ export class Engine {
   update(delta: number) {
     const dt = Math.min(delta, this.maxDelta);
     const g = this.gravity.y * this.gravity.scale;
-    const { width, height } = this.bounds;
+    const { width, height, top } = this.bounds;
     const bodies = this.world.bodies;
     for (const body of bodies) {
       if (body.isStatic) continue;
@@ -171,8 +171,8 @@ export class Engine {
           body.velocity.x = -body.velocity.x * body.restitution;
           body.angularVelocity += (body.velocity.y * 0.01) / body.radius;
         }
-        if (body.position.y - body.radius < 0) {
-          body.position.y = body.radius;
+        if (body.position.y - body.radius < top) {
+          body.position.y = top + body.radius;
           body.velocity.y = -body.velocity.y * body.restitution;
           body.angularVelocity += (body.velocity.x * 0.01) / body.radius;
         } else if (body.position.y + body.radius > height) {


### PR DESCRIPTION
## Summary
- extend physics bounds above the screen for spawn area
- update provider and simulation with new bounds
- cover engine bounds updates in tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fe4a3a30c832aa6d19ba1cb71efbc