### PR TITLE
Remove effects toggle

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -287,72 +287,6 @@ describe('lines module', () => {
     sim.destroy();
   });
 
-  it('toggles character effects', async () => {
-    const div = document.createElement('div');
-    div.getBoundingClientRect = () => ({
-      width: 200,
-      height: 200,
-      top: 0,
-      left: 0,
-      bottom: 200,
-      right: 200,
-      x: 0,
-      y: 0,
-      toJSON: () => {},
-    });
-    let sim!: ReturnType<typeof createFileSimulation>;
-    await act(() => {
-      sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
-      return Promise.resolve();
-    });
-    sim.setEffectsEnabled(false);
-    await act(() => {
-      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
-      return Promise.resolve();
-    });
-    expect(div.querySelector('.add-char')).toBeNull();
-    expect(div.querySelector('.glow-new')).toBeNull();
-    sim.setEffectsEnabled(true);
-    await act(() => {
-      sim.update([{ file: 'a', lines: 2, added: 0, removed: 0 }]);
-      return Promise.resolve();
-    });
-    // TODO: verify character effect rendering once React flushing is reliable
-    sim.destroy();
-  });
-
-  it('shows glow when effects are enabled after mount', async () => {
-    const div = document.createElement('div');
-    div.getBoundingClientRect = () => ({
-      width: 200,
-      height: 200,
-      top: 0,
-      left: 0,
-      bottom: 200,
-      right: 200,
-      x: 0,
-      y: 0,
-      toJSON: () => {},
-    });
-    let sim!: ReturnType<typeof createFileSimulation>;
-    await act(() => {
-      sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
-      return Promise.resolve();
-    });
-    sim.setEffectsEnabled(false);
-    await act(() => {
-      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
-      return Promise.resolve();
-    });
-    sim.setEffectsEnabled(true);
-    await act(() => {
-      sim.update([{ file: 'a', lines: 1, added: 0, removed: 0 }]);
-      return Promise.resolve();
-    });
-    expect(div.querySelector('.glow-new')).toBeTruthy();
-    sim.destroy();
-    div.remove();
-  });
 
   it('limits active character effects', async () => {
     const div = document.createElement('div');
@@ -368,7 +302,6 @@ describe('lines module', () => {
       toJSON: () => {},
     });
     const sim = createFileSimulation(div, { raf: () => 1, now: () => 0 });
-    sim.setEffectsEnabled(true);
     await act(() => {
       sim.update([{ file: 'a', lines: MAX_EFFECT_CHARS * 2, added: 0, removed: 0 }]);
       return Promise.resolve();

--- a/src/__tests__/useFileSimulation.options.test.ts
+++ b/src/__tests__/useFileSimulation.options.test.ts
@@ -11,7 +11,6 @@ const mockSim = {
   resume: jest.fn(),
   resize: jest.fn(),
   destroy: jest.fn(),
-  setEffectsEnabled: jest.fn(),
 };
 
 beforeEach(() => {

--- a/src/__tests__/useFileSimulation.test.ts
+++ b/src/__tests__/useFileSimulation.test.ts
@@ -11,7 +11,6 @@ const mockSim = {
   resume: jest.fn(),
   resize: jest.fn(),
   destroy: jest.fn(),
-  setEffectsEnabled: jest.fn(),
 };
 
 describe('useFileSimulation', () => {
@@ -34,13 +33,11 @@ describe('useFileSimulation', () => {
       result.current.update([]);
       result.current.pause();
       result.current.resume();
-      result.current.setEffectsEnabled(true);
     });
 
     expect(mockSim.update).toHaveBeenCalledWith([]);
     expect(mockSim.pause).toHaveBeenCalled();
     expect(mockSim.resume).toHaveBeenCalled();
-    expect(mockSim.setEffectsEnabled).toHaveBeenCalledWith(true);
   });
 
   it('cleans up on unmount', () => {

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -12,14 +12,12 @@ interface FileCircleProps {
   file: string;
   lines: number;
   radius: number;
-  effectsEnabled?: boolean;
 }
 
 export function FileCircle({
   file,
   lines,
   radius,
-  effectsEnabled = true,
 }: FileCircleProps): React.JSX.Element {
   const [, setTick] = useState(0);
   const forceUpdate = useCallback(() => setTick((t) => t + 1), []);
@@ -39,16 +37,12 @@ export function FileCircle({
   /* eslint-enable no-restricted-syntax */
 
   useEffect(() => {
-    if (effectsEnabled) startGlow('glow-new');
+    startGlow('glow-new');
     prevLines.current = lines;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [effectsEnabled]);
+  }, []);
 
   useEffect(() => {
-    if (!effectsEnabled) {
-      prevLines.current = lines;
-      return;
-    }
     if (prevLines.current === lines) return;
     if (lines > prevLines.current) startGlow('glow-grow');
     else if (lines < prevLines.current) startGlow('glow-shrink');
@@ -63,7 +57,7 @@ export function FileCircle({
       spawnChar(diff > 0 ? 'add-char' : 'remove-char', offset, () => {});
     }
     prevLines.current = lines;
-  }, [lines, effectsEnabled, startGlow, spawnChar, chars.length, currentRadius]);
+  }, [lines, startGlow, spawnChar, chars.length, currentRadius]);
   useEffect(() => {
     if (radius === currentRadius) return;
     body.scale(radius / currentRadius, radius / currentRadius);

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -45,10 +45,9 @@ export interface FileCircleListProps {
   data: LineCount[];
   bounds: { width: number; height: number };
   linear?: boolean;
-  effectsEnabled?: boolean;
 }
 
-export function FileCircleList({ data, bounds, linear, effectsEnabled = true }: FileCircleListProps): React.JSX.Element {
+export function FileCircleList({ data, bounds, linear }: FileCircleListProps): React.JSX.Element {
   const engine = useEngine();
 
   useEffect(() => {
@@ -79,7 +78,6 @@ export function FileCircleList({ data, bounds, linear, effectsEnabled = true }: 
             file={d.file}
             lines={d.lines}
             radius={r}
-            effectsEnabled={effectsEnabled}
           />
         );
       })}

--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -30,7 +30,6 @@ export const createFileSimulation = (
 
   const root = createRoot(container);
   let currentData: LineCount[] = [];
-  let effectsEnabled = true;
 
   const render = (): void => {
     flushSync(() =>
@@ -39,7 +38,6 @@ export const createFileSimulation = (
           <FileCircleList
             data={currentData}
             bounds={{ width, height }}
-            effectsEnabled={effectsEnabled}
             {...(opts.linear !== undefined ? { linear: opts.linear } : {})}
           />
         </PhysicsProvider>,
@@ -92,12 +90,7 @@ export const createFileSimulation = (
     root.unmount();
   };
 
-  const setEffectsEnabled = (state?: boolean): void => {
-    effectsEnabled = state ?? !effectsEnabled;
-    if (currentData.length) render();
-  };
-
-  return { update, pause, resume, resize, destroy, setEffectsEnabled };
+  return { update, pause, resume, resize, destroy };
 };
 
 export const renderFileSimulation = (

--- a/src/client/hooks/useFileSimulation.ts
+++ b/src/client/hooks/useFileSimulation.ts
@@ -33,10 +33,6 @@ export const useFileSimulation = (
   }, [sim]);
   const pause = useCallback(() => sim?.pause(), [sim]);
   const resume = useCallback(() => sim?.resume(), [sim]);
-  const setEffectsEnabled = useCallback(
-    (state?: boolean) => sim?.setEffectsEnabled(state),
-    [sim],
-  );
 
-  return { update, pause, resume, setEffectsEnabled };
+  return { update, pause, resume };
 };


### PR DESCRIPTION
## Summary
- delete ability to toggle character effects
- drop unused tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_684fe78335c8832abde60e72b84134be