### PR TITLE
Skip costly sqrt in physics collisions

### DIFF
--- a/src/client/physics.ts
+++ b/src/client/physics.ts
@@ -191,9 +191,11 @@ export class Engine {
         if (b.isStatic || b.radius === undefined) continue;
         const dx = b.position.x - a.position.x;
         const dy = b.position.y - a.position.y;
-        const dist = Math.hypot(dx, dy);
-        const overlap = a.radius + b.radius - dist;
-        if (overlap <= 0) continue;
+        const radiusSum = a.radius + b.radius;
+        const distSq = dx * dx + dy * dy;
+        if (distSq >= radiusSum * radiusSum) continue;
+        const dist = Math.sqrt(distSq);
+        const overlap = radiusSum - dist;
         const nx = dx / dist;
         const ny = dy / dist;
         const total = a.mass + b.mass;


### PR DESCRIPTION
## Summary
- optimize collision detection by skipping sqrt when bodies are apart

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fe9952158832a9cbddc6318dfe98b