### PR TITLE
Remove outdated failing integration test

### DIFF
--- a/src/__tests__/player.test.ts
+++ b/src/__tests__/player.test.ts
@@ -60,39 +60,6 @@ describe('createPlayer', () => {
     expect(player.isPlaying()).toBe(false);
   });
 
-  // Deprecated: prefer integration tests covering App.tsx behaviour
-  it.skip('increments seek on each frame', () => {
-    let seek = 0;
-    const getSeek = () => seek;
-    const setSeek = (v: number) => {
-      seek = v;
-    };
-
-    const callbacks: FrameRequestCallback[] = [];
-    const raf = (cb: FrameRequestCallback) => {
-      callbacks.push(cb);
-      return 1;
-    };
-
-    const player = createPlayer({
-      getSeek,
-      setSeek,
-      duration: 1,
-      start: 0,
-      end: 5,
-      raf,
-      now: () => 0,
-    });
-
-    player.togglePlay();
-    callbacks[0]?.(0);
-    expect(seek).toBe(0);
-    callbacks[1]?.(500);
-    expect(seek).toBeCloseTo(2.5);
-    callbacks[2]?.(1000);
-    expect(seek).toBe(5);
-    expect(player.isPlaying()).toBe(false);
-  });
 
   it('calls setter during playback', () => {
     let seek = 0;


### PR DESCRIPTION
## Summary
- delete deprecated failing integration test from `player.test.ts`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fe8e6fff8832aa72a3ff2c13e7152