### PR TITLE
Reduce bounds overshoot factor

### DIFF
--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -58,7 +58,7 @@ export function FileCircle({
     const spawn = Math.min(Math.abs(diff), available);
     for (let i = 0; i < spawn; i += 1) {
       const angle = Math.random() * 2 * Math.PI;
-      const r = Math.sqrt(Math.random()) * currentRadius * 2.5;
+      const r = Math.sqrt(Math.random()) * currentRadius * 1.5;
       const offset = { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
       spawnChar(diff > 0 ? 'add-char' : 'remove-char', offset, () => {});
     }


### PR DESCRIPTION
## Summary
- reduce character effect spawn radius from 2x to 1.5x

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fe8b80ce8832a997e077fc1450bca