### PR TITLE
Add scatter effect on file removal

### DIFF
--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -4,8 +4,7 @@ import { useBody } from '../hooks/useBody';
 import { FileCircleContent } from './FileCircleContent';
 import { colorForFile } from '../colors';
 import { useGlowControl } from '../hooks/useGlowControl';
-import { CharEffects } from './CharEffects';
-import { useCharEffects } from '../hooks/useCharEffects';
+import { useGlobalCharEffects } from '../hooks/useGlobalCharEffects';
 import { MAX_EFFECT_CHARS } from '../fileSimulation';
 
 interface FileCircleProps {
@@ -29,7 +28,7 @@ export function FileCircle({
   });
   const [currentRadius, setCurrentRadius] = useState(radius);
   const { startGlow, glowProps } = useGlowControl();
-  const { chars, spawnChar, removeChar } = useCharEffects();
+  const { chars, spawnChar } = useGlobalCharEffects();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const color = useMemo(() => colorForFile(file), []);
   /* eslint-disable no-restricted-syntax */
@@ -58,6 +57,24 @@ export function FileCircle({
     }
     prevLines.current = lines;
   }, [lines, startGlow, spawnChar, chars.length, currentRadius]);
+
+  useEffect(
+    () => () => {
+      const active = chars.length;
+      const available = Math.max(0, MAX_EFFECT_CHARS - active);
+      const spawn = Math.min(lines, available);
+      if (spawn === 0) return;
+      queueMicrotask(() => {
+        for (let i = 0; i < spawn; i += 1) {
+          const angle = Math.random() * 2 * Math.PI;
+          const r = Math.sqrt(Math.random()) * currentRadius * 2.5;
+          const offset = { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
+          spawnChar('remove-char', offset, () => {});
+        }
+      });
+    },
+    [lines, spawnChar, chars.length, currentRadius],
+  );
   useEffect(() => {
     if (radius === currentRadius) return;
     body.scale(radius / currentRadius, radius / currentRadius);
@@ -89,7 +106,6 @@ export function FileCircle({
           name={name}
           count={lines}
         />
-        <CharEffects effects={{ chars, spawnChar, removeChar }} />
       </div>
     </>
   );

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
 import { useEngine } from '../hooks/useEngine';
+import { CharEffectsProvider } from '../hooks/useGlobalCharEffects';
 import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
@@ -32,9 +33,11 @@ export function FileCircleSimulation({ data }: FileCircleSimulationProps): React
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
       {bounds.width > 0 && (
         <PhysicsProvider bounds={bounds}>
-          <PhysicsRunner>
-            <FileCircleList data={data} bounds={bounds} />
-          </PhysicsRunner>
+          <CharEffectsProvider>
+            <PhysicsRunner>
+              <FileCircleList data={data} bounds={bounds} />
+            </PhysicsRunner>
+          </CharEffectsProvider>
         </PhysicsProvider>
       )}
     </div>

--- a/src/client/fileSimulation.tsx
+++ b/src/client/fileSimulation.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { flushSync } from 'react-dom';
 import { FileCircleList } from './components/FileCircleSimulation';
+import { CharEffectsProvider } from './hooks/useGlobalCharEffects';
 import { PhysicsProvider } from './hooks/useEngine';
 import * as Physics from './physics';
 
@@ -35,11 +36,13 @@ export const createFileSimulation = (
     flushSync(() =>
       root.render(
         <PhysicsProvider bounds={{ width, height }} engine={engine}>
-          <FileCircleList
-            data={currentData}
-            bounds={{ width, height }}
-            {...(opts.linear !== undefined ? { linear: opts.linear } : {})}
-          />
+          <CharEffectsProvider>
+            <FileCircleList
+              data={currentData}
+              bounds={{ width, height }}
+              {...(opts.linear !== undefined ? { linear: opts.linear } : {})}
+            />
+          </CharEffectsProvider>
         </PhysicsProvider>,
       ),
     );

--- a/src/client/hooks/useGlobalCharEffects.tsx
+++ b/src/client/hooks/useGlobalCharEffects.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react';
+import { useCharEffects, type CharEffects } from './useCharEffects';
+import { CharEffects as Effects } from '../components/CharEffects';
+
+const CharEffectsContext = createContext<CharEffects | null>(null);
+
+interface ProviderProps {
+  children: React.ReactNode;
+}
+
+export function CharEffectsProvider({ children }: ProviderProps): React.JSX.Element {
+  const effects = useCharEffects();
+  return (
+    <CharEffectsContext.Provider value={effects}>
+      {children}
+      <Effects effects={effects} />
+    </CharEffectsContext.Provider>
+  );
+}
+
+export const useGlobalCharEffects = (): CharEffects => {
+  const ctx = useContext(CharEffectsContext);
+  if (!ctx) throw new Error('useGlobalCharEffects must be used within CharEffectsProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- allow shared character effect pool
- trigger scatter animation when a file circle unmounts

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_684fe8426228832a8fbb4ea3496f0ae1