### PR TITLE
Refactor hooks to manage container refs

### DIFF
--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-syntax
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
 import { useEngine } from '../hooks/useEngine';
@@ -7,26 +6,14 @@ import { CharEffectsProvider } from '../hooks/useGlobalCharEffects';
 import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
+import { useContainerBounds } from '../hooks/useContainerBounds';
 
 interface FileCircleSimulationProps {
   data: LineCount[];
 }
 
 export function FileCircleSimulation({ data }: FileCircleSimulationProps): React.JSX.Element {
-  /* eslint-disable no-restricted-syntax */
-  const containerRef = useRef<HTMLDivElement>(null);
-  /* eslint-enable no-restricted-syntax */
-  const [bounds, setBounds] = useState({ width: 0, height: 0 });
-
-  useEffect(() => {
-    const updateBounds = () => {
-      const rect = containerRef.current?.getBoundingClientRect();
-      setBounds({ width: rect?.width ?? 0, height: rect?.height ?? 0 });
-    };
-    updateBounds();
-    window.addEventListener('resize', updateBounds);
-    return () => window.removeEventListener('resize', updateBounds);
-  }, []);
+  const { ref: containerRef, bounds } = useContainerBounds();
 
   return (
     // eslint-disable-next-line no-restricted-syntax

--- a/src/client/components/SimulationArea.tsx
+++ b/src/client/components/SimulationArea.tsx
@@ -1,6 +1,6 @@
-// eslint-disable-next-line no-restricted-syntax
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useFileSimulation } from '../hooks/useFileSimulation';
+import { useMountedRef } from '../hooks/useMountedRef';
 import type { LineCount } from '../types';
 
 interface SimulationAreaProps {
@@ -8,14 +8,8 @@ interface SimulationAreaProps {
 }
 
 export function SimulationArea({ data }: SimulationAreaProps): React.JSX.Element {
-  /* eslint-disable no-restricted-syntax */
-  const containerRef = useRef<HTMLDivElement>(null);
-  /* eslint-enable no-restricted-syntax */
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-  const { update } = useFileSimulation(mounted ? containerRef.current : null);
+  const { ref: containerRef, element } = useMountedRef<HTMLDivElement>();
+  const { update } = useFileSimulation(element);
 
   useEffect(() => {
     if (data.length) update(data);

--- a/src/client/hooks/useContainerBounds.ts
+++ b/src/client/hooks/useContainerBounds.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line no-restricted-syntax
+import { useEffect, useRef, useState } from 'react';
+
+export const useContainerBounds = () => {
+  // eslint-disable-next-line no-restricted-syntax
+  const ref = useRef<HTMLDivElement>(null);
+  const [bounds, setBounds] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const update = () => {
+      const rect = ref.current?.getBoundingClientRect();
+      setBounds({ width: rect?.width ?? 0, height: rect?.height ?? 0 });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return { ref, bounds } as const;
+};

--- a/src/client/hooks/useMountedRef.ts
+++ b/src/client/hooks/useMountedRef.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-restricted-syntax
+import { useEffect, useRef, useState } from 'react';
+
+export const useMountedRef = <T extends HTMLElement>() => {
+  // eslint-disable-next-line no-restricted-syntax
+  const ref = useRef<T>(null);
+  const [element, setElement] = useState<T | null>(null);
+
+  useEffect(() => {
+    setElement(ref.current);
+  }, []);
+
+  return { ref, element } as const;
+};


### PR DESCRIPTION
## Summary
- add `useMountedRef` hook
- add `useContainerBounds` hook
- refactor `SimulationArea` to use `useMountedRef`
- refactor `FileCircleSimulation` to use `useContainerBounds`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68500081e940832a9ce1563b82fe92fc