### PR TITLE
Fix radius animation infinite loop

### DIFF
--- a/src/__tests__/useRadiusAnimation.test.tsx
+++ b/src/__tests__/useRadiusAnimation.test.tsx
@@ -42,4 +42,16 @@ describe('useRadiusAnimation', () => {
     });
     expect(result.current[0]).toBeCloseTo(20);
   });
+
+  it('returns a stable animate function', () => {
+    const { result } = renderHook(() => useRadiusAnimation(10, 100));
+    const animate = result.current[1];
+
+    act(() => {
+      result.current[1](20);
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(result.current[1]).toBe(animate);
+  });
 });

--- a/src/client/hooks/useRadiusAnimation.ts
+++ b/src/client/hooks/useRadiusAnimation.ts
@@ -9,6 +9,7 @@ export const useRadiusAnimation = (
   /* eslint-disable no-restricted-syntax */
   const fromRef = useRef(initial);
   const targetRef = useRef(initial);
+  const valueRef = useRef(initial);
   const startRef = useRef(0);
   const frameRef = useRef<number | null>(null);
   /* eslint-enable no-restricted-syntax */
@@ -29,16 +30,20 @@ export const useRadiusAnimation = (
     [duration],
   );
 
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
   const animateTo = useCallback(
     (n: number) => {
-      fromRef.current = value;
+      fromRef.current = valueRef.current;
       targetRef.current = n;
       if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
       startRef.current = performance.now();
       setValue(fromRef.current + (n - fromRef.current) * 0.1);
       frameRef.current = requestAnimationFrame(step);
     },
-    [step, value],
+    [step],
   );
 
   useEffect(


### PR DESCRIPTION
## Summary
- keep `animateTo` stable by storing state in a ref
- add regression test for stability

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68500794d5ec832a9a13013db1b54246