### PR TITLE
Fix radius animation loop

### DIFF
--- a/src/__tests__/components/fileCircle.radius.test.tsx
+++ b/src/__tests__/components/fileCircle.radius.test.tsx
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { PhysicsProvider } from '../../client/hooks/useEngine';
+import { FileCircle } from '../../client/components/FileCircle';
+
+jest.useFakeTimers();
+
+describe('FileCircle radius effect', () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+  );
+
+  it('does not exceed update depth when radius changes', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { rerender } = render(
+      <FileCircle file="a" lines={1} radius={10} />, { wrapper: Wrapper }
+    );
+    act(() => {
+      rerender(<FileCircle file="a" lines={1} radius={20} />);
+    });
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Maximum update depth'));
+    errorSpy.mockRestore();
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -58,7 +58,9 @@ export function FileCircle({
 
   useEffect(() => {
     if (radius !== currentRadius) animateRadius(radius);
-  }, [radius, currentRadius, animateRadius]);
+    // currentRadius intentionally omitted from deps to avoid update loops
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [radius, animateRadius]);
 
   useEffect(() => {
     setBodyRadius(currentRadius);


### PR DESCRIPTION
## Summary
- test FileCircle behavior for update loops when radius changes
- stop update loops by omitting `currentRadius` from the deps array

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685018ce0300832a81ac2211d70d6238