### PR TITLE
feat(char-effects): add unmount scatter animation

### DIFF
--- a/src/__tests__/components/fileCircle.radius.test.tsx
+++ b/src/__tests__/components/fileCircle.radius.test.tsx
@@ -2,13 +2,16 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import { PhysicsProvider } from '../../client/hooks/useEngine';
+import { CharEffectsProvider } from '../../client/hooks/useGlobalCharEffects';
 import { FileCircle } from '../../client/components/FileCircle';
 
 jest.useFakeTimers();
 
 describe('FileCircle radius effect', () => {
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
-    <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+    <PhysicsProvider bounds={{ width: 100, height: 100 }}>
+      <CharEffectsProvider>{children}</CharEffectsProvider>
+    </PhysicsProvider>
   );
 
   it('does not exceed update depth when radius changes', () => {

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
 import { useEngine } from '../hooks/useEngine';
+import { CharEffectsProvider } from '../hooks/useGlobalCharEffects';
 import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
@@ -19,9 +20,11 @@ export function FileCircleSimulation({ data }: FileCircleSimulationProps): React
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%' }}>
       {bounds.width > 0 && (
         <PhysicsProvider bounds={bounds}>
-          <PhysicsRunner>
-            <FileCircleList data={data} bounds={bounds} />
-          </PhysicsRunner>
+          <CharEffectsProvider>
+            <PhysicsRunner>
+              <FileCircleList data={data} bounds={bounds} />
+            </PhysicsRunner>
+          </CharEffectsProvider>
         </PhysicsProvider>
       )}
     </div>

--- a/src/client/hooks/useGlobalCharEffects.tsx
+++ b/src/client/hooks/useGlobalCharEffects.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react';
+import { useCharEffects, type CharEffects } from './useCharEffects';
+import { CharEffects as Effects } from '../components/CharEffects';
+
+const CharEffectsContext = createContext<CharEffects | null>(null);
+
+interface ProviderProps {
+  children: React.ReactNode;
+}
+
+export function CharEffectsProvider({ children }: ProviderProps): React.JSX.Element {
+  const effects = useCharEffects();
+  return (
+    <CharEffectsContext.Provider value={effects}>
+      {children}
+      <Effects effects={effects} />
+    </CharEffectsContext.Provider>
+  );
+}
+
+export const useGlobalCharEffects = (): CharEffects => {
+  const ctx = useContext(CharEffectsContext);
+  if (!ctx) throw new Error('useGlobalCharEffects must be used within CharEffectsProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add `useGlobalCharEffects` provider for global character animations
- wrap physics simulation with provider
- trigger scatter effect when `FileCircle` unmounts
- update radius test wrapper

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68501efb748c832a894cf244bcdc19e5