### PR TITLE
codex/remove-filecirclelist-bounds-effect

### DIFF
--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
-import { useEngine } from '../hooks/useEngine';
 import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
@@ -35,13 +34,6 @@ export interface FileCircleListProps {
 }
 
 export function FileCircleList({ data, bounds, linear }: FileCircleListProps): React.JSX.Element {
-  const engine = useEngine();
-
-  useEffect(() => {
-    engine.bounds.width = bounds.width;
-    engine.bounds.height = bounds.height;
-    engine.bounds.top = -bounds.height;
-  }, [engine, bounds.width, bounds.height]);
 
   const scale = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- remove the bounds side effect from `FileCircleList`
- keep bounds updates inside `PhysicsProvider`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_685020c378c8832a8610ad6c1b4a31ee