### PR TITLE
codex/add-element-size-hook

### DIFF
--- a/src/__tests__/useElementSize.test.tsx
+++ b/src/__tests__/useElementSize.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useElementSize } from '../client/hooks/useElementSize';
+
+describe('useElementSize', () => {
+  it('updates size on resize', () => {
+    function Component() {
+      const { ref, size } = useElementSize<HTMLDivElement>();
+      return (
+        // eslint-disable-next-line no-restricted-syntax
+        <div ref={ref} data-width={size.width} data-height={size.height}></div>
+      );
+    }
+    const { container } = render(<Component />);
+    const div = container.firstChild as HTMLDivElement;
+
+    Object.defineProperty(div, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 100, height: 50, top: 0, left: 0, bottom: 0, right: 0 }),
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(div.dataset.width).toBe('100');
+    expect(div.dataset.height).toBe('50');
+
+    Object.defineProperty(div, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 150, height: 75, top: 0, left: 0, bottom: 0, right: 0 }),
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(div.dataset.width).toBe('150');
+    expect(div.dataset.height).toBe('75');
+  });
+});

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -1,5 +1,5 @@
-// eslint-disable-next-line no-restricted-syntax
-import React, { useEffect, useMemo, useState, useRef } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useElementSize } from '../hooks/useElementSize';
 import type { Commit } from '../types';
 
 export interface CommitLogProps {
@@ -11,10 +11,7 @@ export interface CommitLogProps {
 
 export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 }: CommitLogProps): React.JSX.Element => {
   const [offset, setOffset] = useState(0);
-  /* eslint-disable no-restricted-syntax */
-  const containerRef = useRef<HTMLDivElement>(null);
-  /* eslint-enable no-restricted-syntax */
-  const [containerHeight, setContainerHeight] = useState(1);
+  const { ref: containerRef, size } = useElementSize<HTMLDivElement>();
 
   useEffect(() => {
     onTimestampChange?.(timestamp);
@@ -34,19 +31,11 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
     [commits, start, end]
   );
 
-  useEffect(() => {
-    const updateHeight = () =>
-      setContainerHeight(containerRef.current?.clientHeight ?? 1);
-    updateHeight();
-    window.addEventListener('resize', updateHeight);
-    return () => window.removeEventListener('resize', updateHeight);
-  }, []);
-
   const spanMs =
     slice.length > 1
       ? (slice[0]!.timestamp - slice[slice.length - 1]!.timestamp) * 1000
       : 1;
-  const msPerPx = spanMs / Math.max(containerHeight, 1);
+  const msPerPx = spanMs / Math.max(size.height, 1);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -67,7 +56,7 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
     }
     setOffset(nextOffset);
     if (index === 0) container.dispatchEvent(new Event('end'));
-  }, [timestamp, index, commits]);
+  }, [timestamp, index, commits, containerRef]);
 
   return (
     // eslint-disable-next-line no-restricted-syntax

--- a/src/client/hooks/useElementSize.ts
+++ b/src/client/hooks/useElementSize.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line no-restricted-syntax
+import { useEffect, useRef, useState } from 'react';
+
+export const useElementSize = <T extends HTMLElement>() => {
+  // eslint-disable-next-line no-restricted-syntax
+  const ref = useRef<T>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const update = () => {
+      const rect = ref.current?.getBoundingClientRect();
+      setSize({ width: rect?.width ?? 0, height: rect?.height ?? 0 });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return { ref, size } as const;
+};


### PR DESCRIPTION
## Summary
- add `useElementSize` hook for DOM size tracking
- refactor `CommitLog` to use new hook
- drop redundant ESLint overrides
- test `useElementSize` hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_685020cce198832abf38667800f98c97