### PR TITLE
Text scaling based on radius

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path { font-size: 8px; opacity: 0.7; }
-      .file-circle .name { font-size: 12px; }
-      .file-circle .count { font-size: 20px; }
+      .file-circle .path { font-size: calc(var(--r) * 0.4); opacity: 0.7; }
+      .file-circle .name { font-size: calc(var(--r) * 0.6); }
+      .file-circle .count { font-size: calc(var(--r) * 1); }
       .file-circle .chars {
         position: absolute;
         inset: 0;

--- a/src/__tests__/components/fileCircle.fontsize.test.tsx
+++ b/src/__tests__/components/fileCircle.fontsize.test.tsx
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PhysicsProvider } from '../../client/hooks/useEngine';
+import { FileCircle } from '../../client/components/FileCircle';
+
+describe('FileCircle text scaling', () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+  );
+
+  it('sets radius CSS variable', () => {
+    const { container } = render(
+      <FileCircle file="a" lines={1} radius={15} />, { wrapper: Wrapper }
+    );
+    const circle = container.firstElementChild as HTMLElement;
+    expect(circle.style.getPropertyValue('--r')).toBe('15px');
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -82,7 +82,8 @@ export function FileCircle({
           background: color,
           willChange: 'transform',
           transform: `translate3d(${body.position.x - currentRadius}px, ${body.position.y - currentRadius}px, 0) rotate(${body.angle}rad)`,
-        }}
+          '--r': `${currentRadius}px`,
+        } as React.CSSProperties}
       >
         <FileCircleContent
           path={dir.join('/') + (dir.length ? '/' : '')}


### PR DESCRIPTION
## Summary
- scale circle text using CSS variable `--r`
- expose current radius as `--r` in FileCircle style
- verify `--r` style in a new unit test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_68502358cefc832a97efeb600f922f4f