### PR TITLE
increase scaling margin

### DIFF
--- a/src/__tests__/lines.test.ts
+++ b/src/__tests__/lines.test.ts
@@ -47,7 +47,7 @@ describe('lines module', () => {
 
   it('returns eased scale when ratio exceeds threshold', () => {
     const scale = computeScale(1000, 200, [{ file: 'a', lines: 1, added: 0, removed: 0 }]);
-    expect(scale).toBeCloseTo(186.1, 1);
+    expect(scale).toBeCloseTo(168.2, 1);
   });
 
   it('returns 0 when area is zero', () => {

--- a/src/client/scale.ts
+++ b/src/client/scale.ts
@@ -22,7 +22,7 @@ export const computeScale = (
     0,
   );
   const ratio = totalArea / (width * height);
-  const threshold = 0.15;
+  const threshold = 0.1;
   if (!Number.isFinite(ratio) || ratio <= threshold) return base;
   const easing = Math.pow(threshold / ratio, 0.25);
   return base * easing;


### PR DESCRIPTION
## Summary
- adjust global scale threshold to allow more spacing
- update tests for new threshold

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685023f24b38832a85c1b0c88191c970