### PR TITLE
fix font scaling with clamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path { font-size: calc(var(--r) * 0.4); opacity: 0.7; }
-      .file-circle .name { font-size: calc(var(--r) * 0.6); }
-      .file-circle .count { font-size: calc(var(--r) * 1); }
+      .file-circle .path { font-size: clamp(8px, calc(var(--r) * 0.4), 32px); opacity: 0.7; }
+      .file-circle .name { font-size: clamp(8px, calc(var(--r) * 0.6), 48px); }
+      .file-circle .count { font-size: clamp(8px, calc(var(--r) * 1), 64px); }
       .file-circle .chars {
         position: absolute;
         inset: 0;

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('index.html style', () => {
+  it('clamps FileCircle text size', () => {
+    const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
+    expect(html).toMatch(/\.file-circle .count {[^}]*clamp\(/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a test to assert font size clamp in `index.html`
- clamp font sizes of file labels

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685024d195e0832a9b0142b267a719e1