### PR TITLE
Add generic animated number hook

### DIFF
--- a/src/__tests__/useCountAnimation.test.tsx
+++ b/src/__tests__/useCountAnimation.test.tsx
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
-import { useCountAnimation } from '../client/hooks/useCountAnimation';
+import { useAnimatedNumber } from '../client/hooks/useAnimatedNumber';
 
 jest.useFakeTimers();
 
-describe('useCountAnimation', () => {
+describe('useAnimatedNumber (round)', () => {
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
 
@@ -26,7 +26,7 @@ describe('useCountAnimation', () => {
   });
 
   it('eases to the target within duration', () => {
-    const { result } = renderHook(() => useCountAnimation(0, 100));
+    const { result } = renderHook(() => useAnimatedNumber(0, { duration: 100, round: true }));
 
     act(() => {
       result.current[1](100);

--- a/src/__tests__/useRadiusAnimation.test.tsx
+++ b/src/__tests__/useRadiusAnimation.test.tsx
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
-import { useRadiusAnimation } from '../client/hooks/useRadiusAnimation';
+import { useAnimatedNumber } from '../client/hooks/useAnimatedNumber';
 
 jest.useFakeTimers();
 
-describe('useRadiusAnimation', () => {
+describe('useAnimatedNumber', () => {
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
 
@@ -26,7 +26,7 @@ describe('useRadiusAnimation', () => {
   });
 
   it('eases to the target within duration', () => {
-    const { result } = renderHook(() => useRadiusAnimation(10, 100));
+    const { result } = renderHook(() => useAnimatedNumber(10, { duration: 100 }));
 
     act(() => {
       result.current[1](20);
@@ -44,7 +44,7 @@ describe('useRadiusAnimation', () => {
   });
 
   it('returns a stable animate function', () => {
-    const { result } = renderHook(() => useRadiusAnimation(10, 100));
+    const { result } = renderHook(() => useAnimatedNumber(10, { duration: 100 }));
     const animate = result.current[1];
 
     act(() => {

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -5,7 +5,7 @@ import { colorForFile } from '../colors';
 import { useGlowControl } from '../hooks/useGlowControl';
 import { CharEffects } from './CharEffects';
 import { useCharEffects } from '../hooks/useCharEffects';
-import { useRadiusAnimation } from '../hooks/useRadiusAnimation';
+import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
 import { usePrevious } from '../hooks/usePrevious';
 export const MAX_EFFECT_CHARS = 100;
 
@@ -26,7 +26,7 @@ export const FileCircle = React.forwardRef<HTMLDivElement, FileCircleProps>(
     frictionAir: 0.001,
     onUpdate: forceUpdate,
   });
-  const [currentRadius, animateRadius] = useRadiusAnimation(radius);
+  const [currentRadius, animateRadius] = useAnimatedNumber(radius);
   const { startGlow, glowProps } = useGlowControl();
   const { chars, spawnChar, removeChar } = useCharEffects();
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useCountAnimation } from '../hooks/useCountAnimation';
+import { useAnimatedNumber } from '../hooks/useAnimatedNumber';
 import { FilePathDisplay } from './FilePathDisplay';
 
 export interface FileCircleContentProps {
@@ -15,7 +15,7 @@ export function FileCircleContent({
   count,
   hidden,
 }: FileCircleContentProps): React.JSX.Element {
-  const [currentCount, animateCount] = useCountAnimation(count);
+  const [currentCount, animateCount] = useAnimatedNumber(count, { round: true });
 
   useEffect(() => {
     animateCount(count);

--- a/src/client/hooks/useAnimatedNumber.ts
+++ b/src/client/hooks/useAnimatedNumber.ts
@@ -1,0 +1,62 @@
+// eslint-disable-next-line no-restricted-syntax
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface AnimatedNumberOptions {
+  duration?: number;
+  round?: boolean;
+}
+
+export const useAnimatedNumber = (
+  initial: number,
+  { duration = 300, round = false }: AnimatedNumberOptions = {},
+): readonly [number, (n: number) => void] => {
+  const [value, setValue] = useState(initial);
+  /* eslint-disable no-restricted-syntax */
+  const fromRef = useRef(initial);
+  const targetRef = useRef(initial);
+  const valueRef = useRef(initial);
+  const startRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
+  /* eslint-enable no-restricted-syntax */
+
+  const step = useCallback(
+    (time: number) => {
+      const linear = Math.min(1, (time - startRef.current) / duration);
+      const progress = 1 - (1 - linear) ** 2;
+      const next = fromRef.current + (targetRef.current - fromRef.current) * progress;
+      setValue(round ? Math.round(next) : next);
+      if (linear < 1) {
+        frameRef.current = requestAnimationFrame(step);
+      } else {
+        fromRef.current = targetRef.current;
+        frameRef.current = null;
+      }
+    },
+    [duration, round],
+  );
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  const animateTo = useCallback(
+    (n: number) => {
+      fromRef.current = valueRef.current;
+      targetRef.current = n;
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      startRef.current = performance.now();
+      frameRef.current = requestAnimationFrame(step);
+    },
+    [step],
+  );
+
+  useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    },
+    [],
+  );
+
+  return [value, animateTo] as const;
+};
+

--- a/src/client/hooks/useCountAnimation.ts
+++ b/src/client/hooks/useCountAnimation.ts
@@ -1,51 +1,6 @@
-// eslint-disable-next-line no-restricted-syntax
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAnimatedNumber } from './useAnimatedNumber';
 
 export const useCountAnimation = (
   initial: number,
   duration = 300,
-): readonly [number, (n: number) => void] => {
-  const [value, setValue] = useState(initial);
-  /* eslint-disable no-restricted-syntax */
-  const fromRef = useRef(initial);
-  const targetRef = useRef(initial);
-  const startRef = useRef(0);
-  const frameRef = useRef<number | null>(null);
-  /* eslint-enable no-restricted-syntax */
-
-  const step = useCallback(
-    (time: number) => {
-      const linear = Math.min(1, (time - startRef.current) / duration);
-      const progress = 1 - (1 - linear) ** 2;
-      const next =
-        fromRef.current + (targetRef.current - fromRef.current) * progress;
-      setValue(Math.round(next));
-      if (linear < 1) {
-        frameRef.current = requestAnimationFrame(step);
-      } else {
-        fromRef.current = targetRef.current;
-        frameRef.current = null;
-      }
-    },
-    [duration],
-  );
-
-  const animateTo = useCallback(
-    (n: number) => {
-      targetRef.current = n;
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-      startRef.current = performance.now();
-      frameRef.current = requestAnimationFrame(step);
-    },
-    [step],
-  );
-
-  useEffect(
-    () => () => {
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-    },
-    [],
-  );
-
-  return [value, animateTo] as const;
-};
+) => useAnimatedNumber(initial, { duration, round: true });

--- a/src/client/hooks/useRadiusAnimation.ts
+++ b/src/client/hooks/useRadiusAnimation.ts
@@ -1,57 +1,6 @@
-// eslint-disable-next-line no-restricted-syntax
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAnimatedNumber } from './useAnimatedNumber';
 
 export const useRadiusAnimation = (
   initial: number,
   duration = 300,
-): readonly [number, (n: number) => void] => {
-  const [value, setValue] = useState(initial);
-  /* eslint-disable no-restricted-syntax */
-  const fromRef = useRef(initial);
-  const targetRef = useRef(initial);
-  const valueRef = useRef(initial);
-  const startRef = useRef(0);
-  const frameRef = useRef<number | null>(null);
-  /* eslint-enable no-restricted-syntax */
-
-  const step = useCallback(
-    (time: number) => {
-      const linear = Math.min(1, (time - startRef.current) / duration);
-      const progress = 1 - (1 - linear) ** 2;
-      const next = fromRef.current + (targetRef.current - fromRef.current) * progress;
-      setValue(next);
-      if (linear < 1) {
-        frameRef.current = requestAnimationFrame(step);
-      } else {
-        fromRef.current = targetRef.current;
-        frameRef.current = null;
-      }
-    },
-    [duration],
-  );
-
-  useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
-
-  const animateTo = useCallback(
-    (n: number) => {
-      fromRef.current = valueRef.current;
-      targetRef.current = n;
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-      startRef.current = performance.now();
-      setValue(fromRef.current + (n - fromRef.current) * 0.1);
-      frameRef.current = requestAnimationFrame(step);
-    },
-    [step],
-  );
-
-  useEffect(
-    () => () => {
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-    },
-    [],
-  );
-
-  return [value, animateTo] as const;
-};
+) => useAnimatedNumber(initial, { duration });


### PR DESCRIPTION
## Summary
- implement `useAnimatedNumber` to animate numeric values
- wrap `useCountAnimation` and `useRadiusAnimation` around the new hook
- use `useAnimatedNumber` in FileCircle components
- update unit tests to cover the new hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685025f5a6a0832aab0ebff62887af79