### PR TITLE
style(file-circle): reduce font clamp limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path { font-size: clamp(8px, calc(var(--r) * 0.4), 32px); opacity: 0.7; }
-      .file-circle .name { font-size: clamp(8px, calc(var(--r) * 0.6), 48px); }
-      .file-circle .count { font-size: clamp(8px, calc(var(--r) * 1), 64px); }
+      .file-circle .path { font-size: clamp(8px, calc(var(--r) * 0.4), 24px); opacity: 0.7; }
+      .file-circle .name { font-size: clamp(8px, calc(var(--r) * 0.6), 36px); }
+      .file-circle .count { font-size: clamp(8px, calc(var(--r) * 1), 48px); }
       .file-circle .chars {
         position: absolute;
         inset: 0;

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -4,6 +4,8 @@ import path from 'path';
 describe('index.html style', () => {
   it('clamps FileCircle text size', () => {
     const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
+    expect(html).toMatch(/\.file-circle .path {[^}]*clamp\(/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*clamp\(/);
     expect(html).toMatch(/\.file-circle .count {[^}]*clamp\(/);
   });
 });


### PR DESCRIPTION
## Summary
- lower clamp maximums for FileCircle fonts
- verify clamp usage for path and name

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_685026607a84832abcd59c7dcdf1cbad