### PR TITLE
Remove text clamp from FileCircle

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,9 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path { font-size: clamp(8px, calc(var(--r) * 0.4), 24px); opacity: 0.7; }
-      .file-circle .name { font-size: clamp(8px, calc(var(--r) * 0.6), 36px); }
-      .file-circle .count { font-size: clamp(8px, calc(var(--r) * 1), 48px); }
+      .file-circle .path { font-size: calc(var(--r) * 0.4); opacity: 0.7; }
+      .file-circle .name { font-size: calc(var(--r) * 0.6); }
+      .file-circle .count { font-size: calc(var(--r) * 1); }
       .file-circle .chars {
         position: absolute;
         inset: 0;

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -2,10 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 describe('index.html style', () => {
-  it('clamps FileCircle text size', () => {
+  it('scales FileCircle text with radius', () => {
     const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
-    expect(html).toMatch(/\.file-circle .path {[^}]*clamp\(/);
-    expect(html).toMatch(/\.file-circle .name {[^}]*clamp\(/);
-    expect(html).toMatch(/\.file-circle .count {[^}]*clamp\(/);
+    expect(html).toMatch(/\.file-circle .path {[^}]*calc\(var\(--r\)/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*calc\(var\(--r\)/);
+    expect(html).toMatch(/\.file-circle .count {[^}]*calc\(var\(--r\)/);
+    expect(html).not.toMatch(/clamp\(/);
   });
 });


### PR DESCRIPTION
## Summary
- simplify FileCircle font sizing by dropping `clamp`
- adjust test to check for `calc(var(--r)` instead of clamp

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685027e1bd88832a9e5d7b2d321e0531