### PR TITLE
feat(api): websocket line counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-transition-group": "^4.4.5",
+        "ws": "^8.18.2",
         "zod": "^3.25.64"
       },
       "devDependencies": {
@@ -26,6 +27,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/react-transition-group": "^4.4.12",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.34.0",
         "@typescript-eslint/parser": "^8.34.0",
         "@vitejs/plugin-react": "^4.5.2",
@@ -3467,6 +3469,16 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -12085,7 +12097,6 @@
       "version": "8.18.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-transition-group": "^4.4.5",
+    "ws": "^8.18.2",
     "zod": "^3.25.64"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/react-transition-group": "^4.4.12",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
     "@vitejs/plugin-react": "^4.5.2",

--- a/src/__tests__/appFetchCalls.test.tsx
+++ b/src/__tests__/appFetchCalls.test.tsx
@@ -46,18 +46,12 @@ describe('App API calls', () => {
         ([u]) => typeof u === 'string' && u.startsWith('/api/commits') && !u.includes('/lines'),
       ),
     ).toHaveLength(1);
-    expect(
-      fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.includes('/lines')),
-    ).toHaveLength(1);
+    expect(fetchMock.mock.calls.some(([u]) => typeof u === 'string' && u.includes('/lines'))).toBe(false);
 
     const input = container.querySelector('input[type="range"]') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '1500' } });
 
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.filter(([u]) => typeof u === 'string' && u.includes('/lines')).length,
-      ).toBeGreaterThanOrEqual(2),
-    );
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBe(1));
     expect(
       fetchMock.mock.calls.filter(
         ([u]) => typeof u === 'string' && u.startsWith('/api/commits') && !u.includes('/lines'),

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -1,11 +1,14 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
 import type { AddressInfo } from 'net';
 import express from 'express';
+import { createServer } from 'http';
 import { apiMiddleware } from '../server/api-middleware';
 import { appSettings } from '../server/app-settings';
+import { setupLineCountWs } from '../server/ws';
 import { fetchCommits, fetchLineCounts } from '../client/api';
 
 const author = { name: 'a', email: 'a@example.com' };
@@ -23,7 +26,9 @@ describe('server e2e', () => {
     app.set(appSettings.repo.description!, dir);
     app.set(appSettings.branch.description!, 'HEAD');
     app.use(apiMiddleware);
-    const server = app.listen(0);
+    const server = createServer(app);
+    setupLineCountWs(app, server);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;
@@ -51,7 +56,9 @@ describe('server e2e', () => {
     app.set(appSettings.repo.description!, dir);
     app.set(appSettings.branch.description!, 'HEAD');
     app.use(apiMiddleware);
-    const server = app.listen(0);
+    const server = createServer(app);
+    setupLineCountWs(app, server);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;
@@ -76,7 +83,9 @@ describe('server e2e', () => {
     app.set(appSettings.repo.description!, dir);
     app.set(appSettings.branch.description!, 'HEAD');
     app.use(apiMiddleware);
-    const server = app.listen(0);
+    const server = createServer(app);
+    setupLineCountWs(app, server);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;
@@ -103,7 +112,9 @@ describe('server e2e', () => {
     app.set(appSettings.repo.description!, dir);
     app.set(appSettings.branch.description!, 'HEAD');
     app.use(apiMiddleware);
-    const server = app.listen(0);
+    const server = createServer(app);
+    setupLineCountWs(app, server);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
     const { port } = server.address() as AddressInfo;
 
     const base = `http://localhost:${port}`;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import { Command } from 'commander';
+import { createServer } from 'http';
 import { apiMiddleware } from './api-middleware';
 import { appSettings } from './app-settings';
 import { defaultIgnore } from './ignore-defaults';
+import { setupLineCountWs } from './ws';
 
 const collect = (val: string, acc: string[]): string[] => acc.concat(val.split(','));
 
@@ -29,6 +31,10 @@ app.set(appSettings.ignore.description!, ignore);
 app.use(express.static('dist'));
 app.use(apiMiddleware);
 
-app.listen(port, host, () => {
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+const server = createServer(app);
+setupLineCountWs(app, server);
+
+server.listen(port, host, () => {
   console.log(`Server running at http://${host}:${port}`);
 });

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -1,0 +1,68 @@
+import { WebSocketServer } from 'ws';
+import type WebSocket from 'ws';
+import type { Server, IncomingMessage } from 'http';
+import type { Socket } from 'node:net';
+import express from 'express';
+import path from 'path';
+import fs from 'fs';
+import * as git from 'isomorphic-git';
+import { appSettings } from './app-settings';
+import { defaultIgnore } from './ignore-defaults';
+import { getLineCounts, getRenameMap } from './line-counts';
+
+export interface LineCountsRequest {
+  id: string;
+  parent?: string;
+}
+
+export const setupLineCountWs = (app: express.Application, server: Server) => {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    if (req.url?.startsWith('/ws/lines')) {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit('connection', ws, req);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  wss.on('connection', (ws: WebSocket) => {
+    ws.on('message', (data: WebSocket.RawData) => {
+      void (async () => {
+        try {
+          const raw =
+            typeof data === 'string'
+              ? data
+              : Array.isArray(data)
+                ? Buffer.concat(data).toString('utf8')
+                : Buffer.from(data).toString('utf8');
+          const message = JSON.parse(raw) as LineCountsRequest;
+          const dir = path.resolve(
+            (app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd(),
+          );
+          const ignore =
+            (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [...defaultIgnore];
+
+          await git.resolveRef({ fs, dir, ref: message.id });
+          const options = { dir, ref: message.id, ignore } as {
+            dir: string;
+            ref: string;
+            ignore: string[];
+            parent?: string;
+          };
+          if (message.parent) options.parent = message.parent;
+          const counts = await getLineCounts(options);
+          const renames = message.parent
+            ? await getRenameMap({ dir, ref: message.id, parent: message.parent, ignore })
+            : undefined;
+          const payload = renames ? { counts, renames } : { counts };
+          ws.send(JSON.stringify(payload));
+        } catch (error) {
+          ws.send(JSON.stringify({ error: (error as Error).message }));
+        }
+      })();
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- introduce WebSocket server for line count requests
- update client API to use WebSockets
- adjust related tests for WebSocket usage
- install `@types/ws`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685022e10714832a89b17b580960f207