### PR TITLE
Improve websocket URL handling

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -15,8 +15,15 @@ export const fetchLineCounts = async (
   baseUrl = '',
   parent?: string,
 ): Promise<LineCountsResult> => {
-  const protocol = baseUrl.startsWith('https') ? 'wss' : 'ws';
-  const origin = baseUrl.replace(/^https?:\/\//, '');
+  const secure = baseUrl
+    ? baseUrl.startsWith('https')
+    : typeof window !== 'undefined' && window.location.protocol === 'https:';
+  const protocol = secure ? 'wss' : 'ws';
+  const origin = baseUrl
+    ? baseUrl.replace(/^https?:\/\//, '')
+    : typeof window !== 'undefined'
+      ? window.location.host
+      : '';
   const url = `${protocol}://${origin}/ws/lines`;
   return new Promise<LineCountsResult>((resolve, reject) => {
     const socket = new WebSocket(url);


### PR DESCRIPTION
## Summary
- use current location as a fallback when constructing websocket URL

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68502b86abc8832aaa238391b0b0c1a3