### PR TITLE
Implement incremental line count websocket

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -11,4 +11,5 @@ export interface CommitsResponse {
 export interface LineCountsResponse {
   counts: LineCount[];
   renames?: Record<string, string> | undefined;
+  token?: number | undefined;
 }


### PR DESCRIPTION
## Summary
- support tokens in `LineCountsResponse`
- implement persistent websocket handler on the server
- update `useTimelineData` to use a single websocket connection
- adjust the hook tests for the new behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68502d38ee34832a897e26a03a69bf6a