### PR TITLE
Add nowrap styling for circle labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,19 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path { font-size: calc(var(--r) * 0.3); opacity: 0.7; }
-      .file-circle .name { font-size: calc(var(--r) * 0.45); }
-      .file-circle .count { font-size: calc(var(--r) * 0.75); }
+      .file-circle .path {
+        font-size: calc(var(--r) * 0.3);
+        opacity: 0.7;
+        white-space: nowrap;
+      }
+      .file-circle .name {
+        font-size: calc(var(--r) * 0.45);
+        white-space: nowrap;
+      }
+      .file-circle .count {
+        font-size: calc(var(--r) * 0.75);
+        white-space: nowrap;
+      }
       .file-circle .chars {
         position: absolute;
         inset: 0;

--- a/src/__tests__/appDurationControl.test.tsx
+++ b/src/__tests__/appDurationControl.test.tsx
@@ -17,6 +17,14 @@ describe('App duration control', () => {
   beforeEach(() => {
     jest.resetModules();
     document.body.innerHTML = '<div id="root"></div>';
+    global.WebSocket = jest.fn(() => ({
+      send: jest.fn(),
+      close: jest.fn(),
+      addEventListener: (ev: string, cb: (e: MessageEvent) => void) => {
+        if (ev === 'open') cb(new MessageEvent('open'));
+        if (ev === 'message') cb(new MessageEvent('message', { data: JSON.stringify({ counts: [{ file: 'a', lines: 1 }] }) }));
+      },
+    })) as unknown as typeof WebSocket;
     (createPlayer as jest.Mock).mockReturnValue({
       stop: jest.fn(),
       pause: jest.fn(),
@@ -47,6 +55,7 @@ describe('App duration control', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    delete (global as unknown as { WebSocket?: unknown }).WebSocket;
     jest.clearAllMocks();
   });
 

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -5,8 +5,11 @@ describe('index.html style', () => {
   it('scales FileCircle text with radius', () => {
     const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
     expect(html).toMatch(/\.file-circle .path {[^}]*calc\(var\(--r\)/);
+    expect(html).toMatch(/\.file-circle .path {[^}]*white-space: nowrap/);
     expect(html).toMatch(/\.file-circle .name {[^}]*calc\(var\(--r\)/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*white-space: nowrap/);
     expect(html).toMatch(/\.file-circle .count {[^}]*calc\(var\(--r\)/);
+    expect(html).toMatch(/\.file-circle .count {[^}]*white-space: nowrap/);
     expect(html).not.toMatch(/clamp\(/);
   });
 });


### PR DESCRIPTION
## Summary
- prevent wrapping for file circle labels
- test that index.html has nowrap styles
- stub WebSocket in App tests to avoid network errors

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=moderate`


------
https://chatgpt.com/codex/tasks/task_e_68502d7e7d9c832a9b38a3ccaa534fdd