### PR TITLE
Enable WebSocket support in Vite dev server

### DIFF
--- a/src/__tests__/viteExpress.test.ts
+++ b/src/__tests__/viteExpress.test.ts
@@ -1,0 +1,27 @@
+/** @jest-environment node */
+import viteExpress from '../server/vite-express';
+
+jest.mock('../server/ws', () => ({
+  setupLineCountWs: jest.fn(),
+}));
+
+import { setupLineCountWs } from '../server/ws';
+
+interface MockServer {
+  middlewares: { use: jest.Mock };
+  httpServer: unknown;
+}
+
+const createServer = (): MockServer => ({
+  middlewares: { use: jest.fn() },
+  httpServer: {},
+});
+
+describe('viteExpress plugin', () => {
+  it('adds WebSocket support', () => {
+    const server = createServer();
+    const plugin = viteExpress();
+    (plugin.configureServer as (s: MockServer) => void)(server);
+    expect(setupLineCountWs).toHaveBeenCalledWith(expect.anything(), server.httpServer);
+  });
+});

--- a/src/server/vite-express.ts
+++ b/src/server/vite-express.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from 'vite';
 import type { NextHandleFunction } from 'connect';
 import { apiMiddleware } from './api-middleware';
+import { setupLineCountWs } from './ws';
+import type { Server } from 'http';
 import express from 'express';
 
 export default function viteExpress(): Plugin {
@@ -10,6 +12,9 @@ export default function viteExpress(): Plugin {
       const app = express();
       app.use(apiMiddleware);
       server.middlewares.use(app as unknown as NextHandleFunction);
+      if (server.httpServer) {
+        setupLineCountWs(app, server.httpServer as unknown as Server);
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary
- hook the line count WebSocket into the Vite dev plugin
- add tests for the viteExpress plugin

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68502faf8524832aa84eafb4720ce89f