### PR TITLE
feat(file-circle): refine flex text layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,6 @@
       }
       .file-circle {
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
         color: #fff;
@@ -92,18 +91,26 @@
         position: absolute;
         transition: width 1s ease, height 1s ease;
       }
-      .file-circle .path {
-        font-size: calc(var(--r) * 0.3);
-        opacity: 0.7;
+      .file-circle .path,
+      .file-circle .name,
+      .file-circle .count {
+        position: absolute;
+        left: 50%;
+        transform: translate(-50%, -50%);
         white-space: nowrap;
+      }
+      .file-circle .path {
+        top: 30%;
+        max-width: 90%;
+        opacity: 0.7;
       }
       .file-circle .name {
-        font-size: calc(var(--r) * 0.45);
-        white-space: nowrap;
+        top: 50%;
+        max-width: 100%;
       }
       .file-circle .count {
-        font-size: calc(var(--r) * 0.75);
-        white-space: nowrap;
+        top: 70%;
+        max-width: 90%;
       }
       .file-circle .chars {
         position: absolute;

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -2,14 +2,14 @@ import fs from 'fs';
 import path from 'path';
 
 describe('index.html style', () => {
-  it('scales FileCircle text with radius', () => {
+  it('positions FileCircle text with percentages', () => {
     const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
-    expect(html).toMatch(/\.file-circle .path {[^}]*calc\(var\(--r\)/);
-    expect(html).toMatch(/\.file-circle .path {[^}]*white-space: nowrap/);
-    expect(html).toMatch(/\.file-circle .name {[^}]*calc\(var\(--r\)/);
-    expect(html).toMatch(/\.file-circle .name {[^}]*white-space: nowrap/);
-    expect(html).toMatch(/\.file-circle .count {[^}]*calc\(var\(--r\)/);
-    expect(html).toMatch(/\.file-circle .count {[^}]*white-space: nowrap/);
-    expect(html).not.toMatch(/clamp\(/);
+    expect(html).toMatch(/\.file-circle .path {[^}]*top: 30%/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*top: 50%/);
+    expect(html).toMatch(/\.file-circle .count {[^}]*top: 70%/);
+    expect(html).toMatch(/\.file-circle .path {[^}]*max-width: 90%/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*max-width: 100%/);
+    expect(html).toMatch(/\.file-circle .count {[^}]*max-width: 90%/);
+    expect(html).not.toMatch(/calc\(var\(--r\)/);
   });
 });


### PR DESCRIPTION
## Summary
- use flex layout again for `.file-circle`
- set max-width per text line based on its vertical position
- update style test expectations

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68502f70d8b4832a926acd9b7c1c5351