### PR TITLE
codex/usefilecirclerefs

### DIFF
--- a/src/__tests__/useFileCircleRefs.test.tsx
+++ b/src/__tests__/useFileCircleRefs.test.tsx
@@ -1,0 +1,17 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useFileCircleRefs } from '../client/hooks/useFileCircleRefs';
+
+describe('useFileCircleRefs', () => {
+  it('manages refs by file', () => {
+    const { result } = renderHook(() => useFileCircleRefs());
+    const ref1 = result.current.getRef('a');
+    const ref2 = result.current.getRef('a');
+    expect(ref1).toBe(ref2);
+    act(() => {
+      result.current.deleteRef('a');
+    });
+    const ref3 = result.current.getRef('a');
+    expect(ref3).not.toBe(ref1);
+  });
+});

--- a/src/__tests__/viteExpress.test.ts
+++ b/src/__tests__/viteExpress.test.ts
@@ -21,7 +21,7 @@ describe('viteExpress plugin', () => {
   it('adds WebSocket support', () => {
     const server = createServer();
     const plugin = viteExpress();
-    (plugin.configureServer as (s: MockServer) => void)(server);
+    (plugin.configureServer as unknown as (s: MockServer) => void)(server);
     expect(setupLineCountWs).toHaveBeenCalledWith(expect.anything(), server.httpServer);
   });
 });

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react'; // eslint-disable-line no-restricted-syntax
+import React, { useMemo } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
@@ -6,6 +6,7 @@ import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
 import { useContainerBounds } from '../hooks/useContainerBounds';
+import { useFileCircleRefs } from '../hooks/useFileCircleRefs';
 
 interface FileCircleSimulationProps {
   data: LineCount[];
@@ -46,19 +47,14 @@ export function FileCircleList({ data, bounds, linear }: FileCircleListProps): R
     [bounds.width, bounds.height, data, linear],
   );
 
-  const refs = useRef(new Map<string, React.RefObject<HTMLDivElement>>()); // eslint-disable-line no-restricted-syntax
+  const { getRef, deleteRef } = useFileCircleRefs();
 
   return (
     <TransitionGroup component={null}>
       {data.map((d) => {
         const r = (Math.pow(d.lines, 0.5) * scale) / 2;
         if (r * 2 < 1) return null;
-        let nodeRef = refs.current.get(d.file);
-        if (!nodeRef) {
-          // eslint-disable-next-line no-restricted-syntax
-          nodeRef = React.createRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
-          refs.current.set(d.file, nodeRef);
-        }
+        const nodeRef = getRef(d.file);
         return (
           <CSSTransition
             key={d.file}
@@ -66,7 +62,7 @@ export function FileCircleList({ data, bounds, linear }: FileCircleListProps): R
             timeout={500}
             classNames="file-circle-remove"
             onExited={() => {
-              refs.current.delete(d.file);
+              deleteRef(d.file);
             }}
           >
             {/* eslint-disable-next-line no-restricted-syntax */}

--- a/src/client/hooks/useFileCircleRefs.ts
+++ b/src/client/hooks/useFileCircleRefs.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line no-restricted-syntax
+import React, { useCallback, useRef } from 'react';
+
+export const useFileCircleRefs = () => {
+  // eslint-disable-next-line no-restricted-syntax
+  const mapRef = useRef(new Map<string, React.RefObject<HTMLDivElement | null>>());
+
+  const getRef = useCallback((file: string) => {
+    let ref = mapRef.current.get(file);
+    if (!ref) {
+      // eslint-disable-next-line no-restricted-syntax
+      ref = React.createRef<HTMLDivElement>();
+      mapRef.current.set(file, ref);
+    }
+    return ref;
+  }, []);
+
+  const deleteRef = useCallback((file: string) => {
+    mapRef.current.delete(file);
+  }, []);
+
+  return { getRef, deleteRef } as const;
+};


### PR DESCRIPTION
## Summary
- introduce `useFileCircleRefs` hook for managing FileCircle refs
- refactor `FileCircleSimulation` to use the new hook
- fix type cast in `viteExpress` test
- cover `useFileCircleRefs` with a unit test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_685031b7b720832ab002b98c7a71aa62