### PR TITLE
fix circle text width

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,15 +101,18 @@
       }
       .file-circle .path {
         top: 30%;
+        width: 90%;
         max-width: 90%;
         opacity: 0.7;
       }
       .file-circle .name {
         top: 50%;
+        width: 100%;
         max-width: 100%;
       }
       .file-circle .count {
         top: 70%;
+        width: 90%;
         max-width: 90%;
       }
       .file-circle .chars {

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -7,6 +7,9 @@ describe('index.html style', () => {
     expect(html).toMatch(/\.file-circle .path {[^}]*top: 30%/);
     expect(html).toMatch(/\.file-circle .name {[^}]*top: 50%/);
     expect(html).toMatch(/\.file-circle .count {[^}]*top: 70%/);
+    expect(html).toMatch(/\.file-circle .path {[^}]*width: 90%/);
+    expect(html).toMatch(/\.file-circle .name {[^}]*width: 100%/);
+    expect(html).toMatch(/\.file-circle .count {[^}]*width: 90%/);
     expect(html).toMatch(/\.file-circle .path {[^}]*max-width: 90%/);
     expect(html).toMatch(/\.file-circle .name {[^}]*max-width: 100%/);
     expect(html).toMatch(/\.file-circle .count {[^}]*max-width: 90%/);


### PR DESCRIPTION
## Summary
- ensure text containers fill the entire circle width
- check added width properties in style test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_6850365ecf84832aacec350a8ecc7498