### PR TITLE
fix ws upgrade handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ export default {
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^../server/(.*)$': '<rootDir>/src/server/$1.ts',
   },
   testMatch: ['**/__tests__/**/*.test.ts?(x)'],
   testTimeout: 10000,

--- a/src/__tests__/lineCounts.test.ts
+++ b/src/__tests__/lineCounts.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
-import { getLineCounts, getRenameMap } from '../server/line-counts';
+import { getLineCounts, getRenameMap } from '../server/line-counts.js';
 import { defaultIgnore } from '../server/ignore-defaults';
 
 const author = { name: 'a', email: 'a@example.com' };

--- a/src/__tests__/wsUpgrade.test.ts
+++ b/src/__tests__/wsUpgrade.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment node */
+import express from 'express';
+import { createServer, type IncomingMessage } from 'http';
+import type { Socket } from 'node:net';
+import { setupLineCountWs } from '../server/ws';
+
+describe('setupLineCountWs', () => {
+  it('ignores other upgrade paths', () => {
+    const app = express();
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    const server = createServer(app);
+    setupLineCountWs(app, server);
+    const otherHandler = jest.fn();
+    server.on('upgrade', otherHandler);
+
+    const req = { url: '/other' } as unknown as IncomingMessage;
+    const socket = { destroy: jest.fn() } as unknown as Socket;
+
+    server.emit('upgrade', req, socket, Buffer.alloc(0));
+
+    expect(otherHandler).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(socket.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -24,8 +24,6 @@ export const setupLineCountWs = (app: express.Application, server: Server) => {
       wss.handleUpgrade(req, socket, head, (ws) => {
         wss.emit('connection', ws, req);
       });
-    } else {
-      socket.destroy();
     }
   });
 


### PR DESCRIPTION
## Summary
- prevent server from destroying unrelated `upgrade` requests
- fix module resolution for tests
- add regression test for WebSocket upgrades

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_6850354735b8832abd58bc29fb9dbdc6