### PR TITLE
Add useFileCircleRefs hook

### DIFF
--- a/src/__tests__/useFileCircleRefs.test.tsx
+++ b/src/__tests__/useFileCircleRefs.test.tsx
@@ -1,0 +1,21 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useFileCircleRefs } from '../client/hooks/useFileCircleRefs';
+
+describe('useFileCircleRefs', () => {
+  it('returns stable refs and deletes them', () => {
+    const { result } = renderHook(() => useFileCircleRefs());
+
+    const ref1 = result.current.getRef('a');
+    const ref2 = result.current.getRef('a');
+
+    expect(ref1).toBe(ref2);
+
+    act(() => {
+      result.current.deleteRef('a');
+    });
+
+    const ref3 = result.current.getRef('a');
+    expect(ref3).not.toBe(ref1);
+  });
+});

--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react'; // eslint-disable-line no-restricted-syntax
+import React, { useMemo } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { PhysicsProvider } from '../hooks/useEngine';
 import { PhysicsRunner } from '../hooks/useEngineRunner';
@@ -6,6 +6,7 @@ import { FileCircle } from './FileCircle';
 import type { LineCount } from '../types';
 import { computeScale } from '../scale';
 import { useSize } from '../hooks/useSize';
+import { useFileCircleRefs } from '../hooks/useFileCircleRefs';
 
 interface FileCircleSimulationProps {
   data: LineCount[];
@@ -46,19 +47,14 @@ export function FileCircleList({ data, bounds, linear }: FileCircleListProps): R
     [bounds.width, bounds.height, data, linear],
   );
 
-  const refs = useRef(new Map<string, React.RefObject<HTMLDivElement>>()); // eslint-disable-line no-restricted-syntax
+  const { getRef, deleteRef } = useFileCircleRefs();
 
   return (
     <TransitionGroup component={null}>
       {data.map((d) => {
         const r = (Math.pow(d.lines, 0.5) * scale) / 2;
         if (r * 2 < 1) return null;
-        let nodeRef = refs.current.get(d.file);
-        if (!nodeRef) {
-          // eslint-disable-next-line no-restricted-syntax
-          nodeRef = React.createRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
-          refs.current.set(d.file, nodeRef);
-        }
+        const nodeRef = getRef(d.file);
         return (
           <CSSTransition
             key={d.file}
@@ -66,7 +62,7 @@ export function FileCircleList({ data, bounds, linear }: FileCircleListProps): R
             timeout={500}
             classNames="file-circle-remove"
             onExited={() => {
-              refs.current.delete(d.file);
+              deleteRef(d.file);
             }}
           >
             {/* eslint-disable-next-line no-restricted-syntax */}

--- a/src/client/hooks/useFileCircleRefs.ts
+++ b/src/client/hooks/useFileCircleRefs.ts
@@ -1,0 +1,24 @@
+import React, { useCallback } from 'react';
+
+export const useFileCircleRefs = () => {
+  /* eslint-disable no-restricted-syntax */
+  const refs = React.useRef(new Map<string, React.RefObject<HTMLDivElement | null>>());
+  /* eslint-enable no-restricted-syntax */
+
+  const getRef = useCallback((file: string): React.RefObject<HTMLDivElement | null> => {
+    let ref = refs.current.get(file);
+    if (ref === undefined) {
+      /* eslint-disable no-restricted-syntax */
+      ref = React.createRef<HTMLDivElement>();
+      /* eslint-enable no-restricted-syntax */
+      refs.current.set(file, ref);
+    }
+    return ref;
+  }, []);
+
+  const deleteRef = useCallback((file: string): void => {
+    refs.current.delete(file);
+  }, []);
+
+  return { getRef, deleteRef } as const;
+};


### PR DESCRIPTION
## Summary
- manage FileCircle refs in a new `useFileCircleRefs` hook
- refactor `FileCircleSimulation` to use the hook
- test the new hook

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685037405a68832ab05fcdc56018ff0a