### PR TITLE
feat(ui): :sparkles: scale circle text by radius

### DIFF
--- a/src/__tests__/components/fileCircle.textSize.test.tsx
+++ b/src/__tests__/components/fileCircle.textSize.test.tsx
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { PhysicsProvider } from '../../client/hooks/useEngine';
+import { FileCircle } from '../../client/components/FileCircle';
+
+jest.useFakeTimers();
+
+describe('FileCircle text size', () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+  );
+
+  it('scales text based on radius', () => {
+    const { container } = render(<FileCircle file="a" lines={1} radius={20} />, { wrapper: Wrapper });
+    const path = container.querySelector('.path') as HTMLElement;
+    const name = container.querySelector('.name') as HTMLElement;
+    const count = container.querySelector('.count') as HTMLElement;
+    expect(path.style.fontSize).toBe('6px');
+    expect(name.style.fontSize).toBe('7px');
+    expect(count.style.fontSize).toBe('6px');
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -124,6 +124,7 @@ export const FileCircle = React.forwardRef<HTMLDivElement, FileCircleProps>(
           path={dir.join('/') + (dir.length ? '/' : '')}
           name={name}
           count={lines}
+          radius={currentRadius}
         />
         <CharEffects effects={{ chars, spawnChar, removeChar }} />
       </div>

--- a/src/client/components/FileCircleContent.tsx
+++ b/src/client/components/FileCircleContent.tsx
@@ -6,6 +6,7 @@ export interface FileCircleContentProps {
   path: string;
   name: string;
   count: number;
+  radius: number;
   hidden?: boolean;
 }
 
@@ -13,6 +14,7 @@ export function FileCircleContent({
   path,
   name,
   count,
+  radius,
   hidden,
 }: FileCircleContentProps): React.JSX.Element {
   const [currentCount, animateCount] = useAnimatedNumber(count, { round: true });
@@ -23,8 +25,21 @@ export function FileCircleContent({
 
   return (
     <>
-      <FilePathDisplay path={path} name={name} hidden={hidden} />
-      <div className="count" style={{ display: hidden ? 'none' : undefined }}>{currentCount}</div>
+      <FilePathDisplay
+        path={path}
+        name={name}
+        radius={radius}
+        hidden={hidden}
+      />
+      <div
+        className="count"
+        style={{
+          display: hidden ? 'none' : undefined,
+          fontSize: `${radius * 0.3}px`,
+        }}
+      >
+        {currentCount}
+      </div>
     </>
   );
 }

--- a/src/client/components/FilePathDisplay.tsx
+++ b/src/client/components/FilePathDisplay.tsx
@@ -4,22 +4,34 @@ import { useTypewriter } from '../hooks/useTypewriter';
 export interface FilePathDisplayProps {
   path: string;
   name: string;
+  radius: number;
   hidden?: boolean | undefined;
 }
 
 export function FilePathDisplay({
   path,
   name,
+  radius,
   hidden,
 }: FilePathDisplayProps): React.JSX.Element {
   const typedPath = useTypewriter(path);
   const typedName = useTypewriter(name);
-  const style = hidden ? { display: 'none' } : undefined;
+  const baseStyle = hidden ? { display: 'none' } : undefined;
+
+  const pathStyle = {
+    ...baseStyle,
+    fontSize: `${radius * 0.3}px`,
+  } as React.CSSProperties;
+
+  const nameStyle = {
+    ...baseStyle,
+    fontSize: `${radius * 0.35}px`,
+  } as React.CSSProperties;
 
   return (
     <>
-      <div className="path" style={style}>{typedPath}</div>
-      <div className="name" style={style}>{typedName}</div>
+      <div className="path" style={pathStyle}>{typedPath}</div>
+      <div className="name" style={nameStyle}>{typedName}</div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- scale text inside FileCircle according to its radius
- adjust FilePathDisplay and FileCircleContent to accept radius prop
- test text scaling logic

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_6850379bbbac832a97d27cf55411fed7