### PR TITLE
feat(client): ✨ build ws url helper

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,5 +1,6 @@
 import type { Commit, LineCountsResult } from './types';
 import type { ApiError, CommitsResponse, LineCountsResponse } from '../api/types';
+import { buildWsUrl } from './ws';
 
 export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
   const response = await fetch(`${baseUrl}/api/commits`);
@@ -15,16 +16,7 @@ export const fetchLineCounts = async (
   baseUrl = '',
   parent?: string,
 ): Promise<LineCountsResult> => {
-  const secure = baseUrl
-    ? baseUrl.startsWith('https')
-    : typeof window !== 'undefined' && window.location.protocol === 'https:';
-  const protocol = secure ? 'wss' : 'ws';
-  const origin = baseUrl
-    ? baseUrl.replace(/^https?:\/\//, '')
-    : typeof window !== 'undefined'
-      ? window.location.host
-      : '';
-  const url = `${protocol}://${origin}/ws/lines`;
+  const url = buildWsUrl('/ws/lines', baseUrl);
   return new Promise<LineCountsResult>((resolve, reject) => {
     const socket = new WebSocket(url);
     socket.addEventListener('open', () => {

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { readCommits } from '../commitsResource';
+import { buildWsUrl } from '../ws';
 import type { LineCount } from '../types';
 import type { LineCountsResponse, ApiError } from '../../api/types';
 
@@ -43,16 +44,7 @@ const useLineCountsQueue = (baseUrl?: string) => {
 
   const connect = useCallback(() => {
     if (socketRef.current) return;
-    const secure = baseUrl
-      ? baseUrl.startsWith('https')
-      : typeof window !== 'undefined' && window.location.protocol === 'https:';
-    const protocol = secure ? 'wss' : 'ws';
-    const origin = baseUrl
-      ? baseUrl.replace(/^https?:\/\//, '')
-      : typeof window !== 'undefined'
-        ? window.location.host
-        : '';
-    const socket = new WebSocket(`${protocol}://${origin}/ws/lines`);
+    const socket = new WebSocket(buildWsUrl('/ws/lines', baseUrl));
     socket.addEventListener('open', sendQueued);
     socket.addEventListener('message', handleMessage);
     socket.addEventListener('close', () => {

--- a/src/client/ws.ts
+++ b/src/client/ws.ts
@@ -1,0 +1,12 @@
+export const buildWsUrl = (path: string, baseUrl = ''): string => {
+  const secure = baseUrl
+    ? baseUrl.startsWith('https')
+    : typeof window !== 'undefined' && window.location.protocol === 'https:';
+  const protocol = secure ? 'wss' : 'ws';
+  const origin = baseUrl
+    ? baseUrl.replace(/^https?:\/\//, '')
+    : typeof window !== 'undefined'
+      ? window.location.host
+      : '';
+  return `${protocol}://${origin}${path}`;
+};


### PR DESCRIPTION
## Summary
- create `buildWsUrl` helper
- centralize WebSocket URL handling in `fetchLineCounts` and `useTimelineData`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68503a81bde0832aa2d290c63f62c75c