### PR TITLE
fix websocket priority

### DIFF
--- a/src/__tests__/wsPrepend.test.ts
+++ b/src/__tests__/wsPrepend.test.ts
@@ -1,0 +1,32 @@
+/** @jest-environment node */
+import express from 'express';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import { setupLineCountWs } from '../server/ws';
+
+it('handles upgrades before other listeners', async () => {
+  const app = express();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  const server = createServer(app);
+  // other listener that destroys the socket
+  server.on('upgrade', (_req, socket) => {
+    socket.destroy();
+  });
+  setupLineCountWs(app, server);
+  await new Promise((resolve) => server.listen(0, resolve as () => void));
+  const { port } = server.address() as AddressInfo;
+
+  await expect(
+    new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${port}/ws/lines`);
+      ws.on('open', () => {
+        ws.terminate();
+        resolve();
+      });
+      ws.on('error', reject);
+    }),
+  ).resolves.toBeUndefined();
+
+  server.close();
+});

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -19,13 +19,16 @@ export interface LineCountsRequest {
 export const setupLineCountWs = (app: express.Application, server: Server) => {
   const wss = new WebSocketServer({ noServer: true });
 
-  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
-    if (req.url?.startsWith('/ws/lines')) {
-      wss.handleUpgrade(req, socket, head, (ws) => {
-        wss.emit('connection', ws, req);
-      });
-    }
-  });
+  server.prependListener(
+    'upgrade',
+    (req: IncomingMessage, socket: Socket, head: Buffer) => {
+      if (req.url?.startsWith('/ws/lines')) {
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit('connection', ws, req);
+        });
+      }
+    },
+  );
 
   wss.on('connection', (ws: WebSocket) => {
     let previous: string | undefined;


### PR DESCRIPTION
## Summary
- ensure custom WebSocket upgrade runs before others
- add regression test for upgrade order

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_68503bb8e038832a9f5f32e6f96a3d5f