### PR TITLE
Add rotational friction on wall collision

### DIFF
--- a/src/__tests__/engineWallFriction.test.ts
+++ b/src/__tests__/engineWallFriction.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+import { Engine, Body } from '../client/physics';
+
+describe('Engine wall friction', () => {
+  it('adds spin when hitting walls', () => {
+    const engine = new Engine(100, 100);
+    engine.gravity.y = 0;
+    const body = new Body({
+      position: { x: 10, y: 50 },
+      velocity: { x: -1, y: 1 },
+      radius: 10,
+      friction: 0.5,
+    });
+    engine.add(body);
+
+    for (let i = 0; i < 30; i += 1) {
+      engine.update(16);
+    }
+
+    expect(Math.abs(body.angularVelocity)).toBeGreaterThan(0);
+  });
+});

--- a/src/client/physics.ts
+++ b/src/client/physics.ts
@@ -163,21 +163,29 @@ export class Engine {
       if (body.radius !== undefined) {
         if (body.position.x - body.radius < 0) {
           body.position.x = body.radius;
+          const vy = body.velocity.y;
           body.velocity.x *= -body.restitution;
           body.velocity.y *= 1 - body.friction;
+          body.angularVelocity -= (body.velocity.y - vy) / body.radius;
         } else if (body.position.x + body.radius > width) {
           body.position.x = width - body.radius;
+          const vy = body.velocity.y;
           body.velocity.x *= -body.restitution;
           body.velocity.y *= 1 - body.friction;
+          body.angularVelocity += (body.velocity.y - vy) / body.radius;
         }
         if (body.position.y - body.radius < top) {
           body.position.y = top + body.radius;
+          const vx = body.velocity.x;
           body.velocity.y *= -body.restitution;
           body.velocity.x *= 1 - body.friction;
+          body.angularVelocity += (body.velocity.x - vx) / body.radius;
         } else if (body.position.y + body.radius > height) {
           body.position.y = height - body.radius;
+          const vx = body.velocity.x;
           body.velocity.y *= -body.restitution;
           body.velocity.x *= 1 - body.friction;
+          body.angularVelocity -= (body.velocity.x - vx) / body.radius;
         }
       }
 


### PR DESCRIPTION
## Summary
- spin bodies when colliding with walls
- test rotation from wall friction

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_685042781b9c832a8fabd786a668e1cf