### PR TITLE
feat(style): center text inside circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        flex-direction: column;
         color: #fff;
         font-family: sans-serif;
         text-align: center;
@@ -97,26 +98,20 @@
       .file-circle .path,
       .file-circle .name,
       .file-circle .count {
-        position: absolute;
-        left: 50%;
-        transform: translate(-50%, -50%);
         white-space: nowrap;
       }
       .file-circle .path {
-        top: 30%;
         font-size: calc(var(--radius) * 0.15);
         width: 90%;
         max-width: 90%;
         opacity: 0.7;
       }
       .file-circle .name {
-        top: 50%;
         font-size: calc(var(--radius) * 0.175);
         width: 100%;
         max-width: 100%;
       }
       .file-circle .count {
-        top: 70%;
         font-size: calc(var(--radius) * 0.3);
         width: 90%;
         max-width: 90%;

--- a/src/__tests__/index.style.test.ts
+++ b/src/__tests__/index.style.test.ts
@@ -2,11 +2,12 @@ import fs from 'fs';
 import path from 'path';
 
 describe('index.html style', () => {
-  it('positions FileCircle text with percentages', () => {
+  it('centers FileCircle text with flexbox', () => {
     const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
-    expect(html).toMatch(/\.file-circle .path {[^}]*top: 30%/);
-    expect(html).toMatch(/\.file-circle .name {[^}]*top: 50%/);
-    expect(html).toMatch(/\.file-circle .count {[^}]*top: 70%/);
+    expect(html).toMatch(/\.file-circle {[^}]*flex-direction: column/);
+    expect(html).not.toMatch(/\.file-circle .path {[^}]*top:/);
+    expect(html).not.toMatch(/\.file-circle .name {[^}]*top:/);
+    expect(html).not.toMatch(/\.file-circle .count {[^}]*top:/);
     expect(html).toMatch(/\.file-circle .path {[^}]*width: 90%/);
     expect(html).toMatch(/\.file-circle .name {[^}]*width: 100%/);
     expect(html).toMatch(/\.file-circle .count {[^}]*width: 90%/);


### PR DESCRIPTION
## Summary
- center circle text using flexbox
- adjust style test for new layout

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_685049811918832ab3981a4f1cac5d04