### PR TITLE
Add hook tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ export default {
   ],
   coverageThreshold: {
     global: {
-      lines: 70, // TODO: restore to 80 when hook tests are added
+      lines: 80,
     },
   },
 };

--- a/src/__tests__/useCountAnimation.test.tsx
+++ b/src/__tests__/useCountAnimation.test.tsx
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
-import { useAnimatedNumber } from '../client/hooks/useAnimatedNumber';
+import { useCountAnimation } from '../client/hooks/useCountAnimation';
 
 jest.useFakeTimers();
 
-describe('useAnimatedNumber (round)', () => {
+describe('useCountAnimation', () => {
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
 
@@ -25,8 +25,8 @@ describe('useAnimatedNumber (round)', () => {
     global.requestAnimationFrame = originalRaf;
   });
 
-  it('eases to the target within duration', () => {
-    const { result } = renderHook(() => useAnimatedNumber(0, { duration: 100, round: true }));
+  it('eases to the target within duration and rounds', () => {
+    const { result } = renderHook(() => useCountAnimation(0, 100));
 
     act(() => {
       result.current[1](100);
@@ -36,10 +36,24 @@ describe('useAnimatedNumber (round)', () => {
       jest.advanceTimersByTime(50);
     });
     expect(result.current[0]).toBeGreaterThan(50);
+    expect(Number.isInteger(result.current[0])).toBe(true);
 
     act(() => {
       jest.advanceTimersByTime(60);
     });
     expect(result.current[0]).toBe(100);
+    expect(Number.isInteger(result.current[0])).toBe(true);
+  });
+
+  it('returns a stable animate function', () => {
+    const { result } = renderHook(() => useCountAnimation(0, 100));
+    const animate = result.current[1];
+
+    act(() => {
+      result.current[1](10);
+      jest.advanceTimersByTime(120);
+    });
+
+    expect(result.current[1]).toBe(animate);
   });
 });

--- a/src/__tests__/useRadiusAnimation.test.tsx
+++ b/src/__tests__/useRadiusAnimation.test.tsx
@@ -1,10 +1,10 @@
 /** @jest-environment jsdom */
 import { renderHook, act } from '@testing-library/react';
-import { useAnimatedNumber } from '../client/hooks/useAnimatedNumber';
+import { useRadiusAnimation } from '../client/hooks/useRadiusAnimation';
 
 jest.useFakeTimers();
 
-describe('useAnimatedNumber', () => {
+describe('useRadiusAnimation', () => {
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
 
@@ -26,7 +26,7 @@ describe('useAnimatedNumber', () => {
   });
 
   it('eases to the target within duration', () => {
-    const { result } = renderHook(() => useAnimatedNumber(10, { duration: 100 }));
+    const { result } = renderHook(() => useRadiusAnimation(10, 100));
 
     act(() => {
       result.current[1](20);
@@ -44,7 +44,7 @@ describe('useAnimatedNumber', () => {
   });
 
   it('returns a stable animate function', () => {
-    const { result } = renderHook(() => useAnimatedNumber(10, { duration: 100 }));
+    const { result } = renderHook(() => useRadiusAnimation(10, 100));
     const animate = result.current[1];
 
     act(() => {


### PR DESCRIPTION
## Summary
- test round/target behavior of `useCountAnimation`
- test reference stability of `useRadiusAnimation`
- enforce 80% global coverage again

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_68504d30735c832a8a7cdb69bf14cad0