### PR TITLE
feat(cli): add repository path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ npm start                # defaults to current directory
 # npm run dev            # start Vite dev server with API
 ```
 
+CLI options can also be provided via environment variables with the `BLOBLOOM_` prefix.
+For example, set `BLOBLOOM_REPO` to specify the repository path.
+
 Then open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Headless Tests

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,21 +10,36 @@ const collect = (val: string, acc: string[]): string[] => acc.concat(val.split('
 
 const program = new Command();
 program
-  .option('-b, --branch <name>', 'branch to inspect')
-  .option('-H, --host <host>', 'host name to listen on', 'localhost')
-  .option('-p, --port <number>', 'port to listen on', (v) => Number(v), 3000)
-  .option('-i, --ignore <pattern>', 'glob pattern to ignore', collect, [...defaultIgnore]);
+  .option('-r, --repo <path>', 'git repository path', process.env.BLOBLOOM_REPO)
+  .option('-b, --branch <name>', 'branch to inspect', process.env.BLOBLOOM_BRANCH)
+  .option('-H, --host <host>', 'host name to listen on', process.env.BLOBLOOM_HOST ?? 'localhost')
+  .option(
+    '-p, --port <number>',
+    'port to listen on',
+    (v) => Number(v),
+    process.env.BLOBLOOM_PORT ? Number(process.env.BLOBLOOM_PORT) : 3000,
+  )
+  .option(
+    '-i, --ignore <pattern>',
+    'glob pattern to ignore',
+    collect,
+    process.env.BLOBLOOM_IGNORE
+      ? process.env.BLOBLOOM_IGNORE.split(',')
+      : [...defaultIgnore],
+  );
 
 program.parse();
 
-const { host, port, branch, ignore } = program.opts<{
+const { host, port, branch, ignore, repo } = program.opts<{
   host: string;
   port: number;
   branch?: string;
   ignore: string[];
+  repo?: string;
 }>();
 
 const app = express();
+app.set(appSettings.repo.description!, repo);
 app.set(appSettings.branch.description!, branch);
 app.set(appSettings.ignore.description!, ignore);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  envPrefix: ['VITE_', 'BLOBLOOM_'],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- add `--repo` to CLI with env var defaults
- expose env vars to Vite
- document `BLOBLOOM_` env vars

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68504da211b8832aa9f077c5e4132dbb