### PR TITLE
fix: reflect body rotation css variable

### DIFF
--- a/src/__tests__/components/fileCircle.rotation.test.tsx
+++ b/src/__tests__/components/fileCircle.rotation.test.tsx
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import type { Engine } from '../../client/physics';
+import { PhysicsProvider, useEngine } from '../../client/hooks/useEngine';
+import { FileCircle } from '../../client/components/FileCircle';
+
+jest.useFakeTimers();
+
+describe('FileCircle rotation CSS variable', () => {
+  let engine: Engine | undefined;
+  const CaptureEngine = () => {
+    engine = useEngine();
+    return null;
+  };
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <PhysicsProvider bounds={{ width: 100, height: 100 }}>
+      <CaptureEngine />
+      {children}
+    </PhysicsProvider>
+  );
+
+  it('updates --rotate when body angle changes', () => {
+    const { container } = render(
+      <FileCircle file="a" lines={1} radius={10} />, { wrapper: Wrapper },
+    );
+    const circle = container.querySelector('.file-circle') as HTMLElement;
+    expect(circle.style.getPropertyValue('--rotate')).toBe('0rad');
+
+    act(() => {
+      const body = engine!.world.bodies[0]!;
+      body.angle = Math.PI / 2;
+      body.onUpdate?.(body);
+    });
+
+    expect(circle.style.getPropertyValue('--rotate')).toBe(`${Math.PI / 2}rad`);
+  });
+});

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -110,6 +110,7 @@ export const FileCircle = React.forwardRef<HTMLDivElement, FileCircleProps>(
         style={{
           position: 'absolute',
           '--radius': `${currentRadius}px`,
+          '--rotate': `${body.angle}rad`,
           width: 'calc(var(--radius) * 2)',
           height: 'calc(var(--radius) * 2)',
           borderRadius: '50%',


### PR DESCRIPTION
## Summary
- expose physics body rotation as `--rotate` CSS variable
- test that rotation is reflected via CSS custom property

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68504e819b80832a941e1e68f4eda03f