### PR TITLE
Replace Math.pow with exponent operator

### DIFF
--- a/src/client/components/FileCircleSimulation.tsx
+++ b/src/client/components/FileCircleSimulation.tsx
@@ -52,7 +52,7 @@ export function FileCircleList({ data, bounds, linear }: FileCircleListProps): R
   return (
     <TransitionGroup component={null}>
       {data.map((d) => {
-        const r = (Math.pow(d.lines, 0.5) * scale) / 2;
+        const r = ((d.lines ** 0.5) * scale) / 2;
         if (r * 2 < 1) return null;
         const nodeRef = getRef(d.file);
         return (

--- a/src/client/scale.ts
+++ b/src/client/scale.ts
@@ -12,11 +12,11 @@ export const computeScale = (
     (m, d) => Math.max(m, Number.isFinite(d.lines) ? d.lines : 0),
     1,
   );
-  const base = Math.min(width, height) / Math.pow(maxLines, exp);
+  const base = Math.min(width, height) / maxLines ** exp;
   const totalArea = data.reduce(
     (sum, f) => {
       const lines = Number.isFinite(f.lines) ? f.lines : 0;
-      const r = (Math.pow(lines, exp) * base) / 2;
+      const r = ((lines ** exp) * base) / 2;
       return sum + 4 * r ** 2;
     },
     0,
@@ -24,6 +24,6 @@ export const computeScale = (
   const ratio = totalArea / (width * height);
   const threshold = 0.1;
   if (!Number.isFinite(ratio) || ratio <= threshold) return base;
-  const easing = Math.pow(threshold / ratio, 0.25);
+  const easing = (threshold / ratio) ** 0.25;
   return base * easing;
 };


### PR DESCRIPTION
## Summary
- modernize exponent usage in FileCircleSimulation and scale calculation
- ensure existing functionality with lint, test, and build

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_6850513ef170832a9f89f642afa8a605