### PR TITLE
Add app test helper

### DIFF
--- a/src/__tests__/appCommitLog.test.tsx
+++ b/src/__tests__/appCommitLog.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { App } from '../client/App';
+import { setupAppTest } from './helpers/app';
 
 const commits = [
   { id: 'n', message: 'new', timestamp: 2 },
@@ -9,35 +10,15 @@ const commits = [
 ];
 
 describe('App commit log', () => {
-  const originalFetch = global.fetch;
+  let restore: () => void;
 
   beforeEach(() => {
     jest.resetModules();
-    document.body.innerHTML = '<div id="root"></div>';
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      if (typeof input === 'string' && input.startsWith('/api/commits')) {
-        if (input.endsWith('/lines')) {
-          return Promise.resolve({
-            json: () =>
-              Promise.resolve({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }),
-          });
-        }
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
-      }
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      return Promise.reject(new Error(`Unexpected url: ${url}`));
-    }) as jest.Mock;
+    restore = setupAppTest({ commits });
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
+    restore();
   });
 
   it('renders commit log after loading', async () => {

--- a/src/__tests__/appDurationControl.test.tsx
+++ b/src/__tests__/appDurationControl.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import { App } from '../client/App';
 import { createPlayer } from '../client/player';
+import { setupAppTest } from './helpers/app';
 
 jest.mock('../client/player');
 
@@ -12,19 +13,11 @@ const commits = [
 ];
 
 describe('App duration control', () => {
-  const originalFetch = global.fetch;
+  let restore: () => void;
 
   beforeEach(() => {
     jest.resetModules();
-    document.body.innerHTML = '<div id="root"></div>';
-    global.WebSocket = jest.fn(() => ({
-      send: jest.fn(),
-      close: jest.fn(),
-      addEventListener: (ev: string, cb: (e: MessageEvent) => void) => {
-        if (ev === 'open') cb(new MessageEvent('open'));
-        if (ev === 'message') cb(new MessageEvent('message', { data: JSON.stringify({ counts: [{ file: 'a', lines: 1 }] }) }));
-      },
-    })) as unknown as typeof WebSocket;
+    restore = setupAppTest({ commits });
     (createPlayer as jest.Mock).mockReturnValue({
       stop: jest.fn(),
       pause: jest.fn(),
@@ -32,30 +25,10 @@ describe('App duration control', () => {
       togglePlay: jest.fn(),
       isPlaying: jest.fn(() => false),
     });
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      if (typeof input === 'string' && input.startsWith('/api/commits')) {
-        if (input.endsWith('/lines')) {
-          return Promise.resolve({
-            json: () => Promise.resolve({ counts: [{ file: 'a', lines: 1 }] }),
-          });
-        }
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
-      }
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      return Promise.reject(new Error(`Unexpected url: ${url}`));
-    }) as jest.Mock;
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
-    delete (global as unknown as { WebSocket?: unknown }).WebSocket;
+    restore();
     jest.clearAllMocks();
   });
 

--- a/src/__tests__/appPlayPause.test.tsx
+++ b/src/__tests__/appPlayPause.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, waitFor, act, fireEvent } from '@testing-library/react';
 import { App } from '../client/App';
+import { setupAppTest } from './helpers/app';
 
 const commits = [
   { id: 'n', message: 'new', timestamp: 2 },
@@ -9,34 +10,14 @@ const commits = [
 ];
 
 describe('App play/pause', () => {
-  const originalFetch = global.fetch;
   const originalRaf = global.requestAnimationFrame;
   let now = 0;
+  let restore: () => void;
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.resetModules();
-    document.body.innerHTML = '<div id="root"></div>';
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      if (typeof input === 'string' && input.startsWith('/api/commits')) {
-        if (input.endsWith('/lines')) {
-          return Promise.resolve({
-            json: () =>
-              Promise.resolve({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }),
-          });
-        }
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) });
-      }
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      return Promise.reject(new Error(`Unexpected url: ${url}`));
-    }) as jest.Mock;
+    restore = setupAppTest({ commits });
     jest.spyOn(performance, 'now').mockImplementation(() => now);
     global.requestAnimationFrame = (cb: FrameRequestCallback) => {
       return setTimeout(() => {
@@ -49,8 +30,8 @@ describe('App play/pause', () => {
   afterEach(() => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
-    global.fetch = originalFetch;
     global.requestAnimationFrame = originalRaf;
+    restore();
   });
 
   it('pauses and resumes playback when toggled', async () => {

--- a/src/__tests__/helpers/app.ts
+++ b/src/__tests__/helpers/app.ts
@@ -1,0 +1,60 @@
+export interface SetupAppOptions {
+  commits?: { id: string; message: string; timestamp: number }[];
+  lineCounts?: { file: string; lines: number; added?: number; removed?: number }[];
+}
+
+const defaultCommits = [
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
+];
+
+const defaultLineCounts = [
+  { file: 'a', lines: 1 },
+];
+
+export const setupAppTest = (
+  options: SetupAppOptions = {},
+): (() => void) => {
+  const { commits = defaultCommits, lineCounts = defaultLineCounts } = options;
+  const originalFetch = global.fetch;
+  const originalWs = (global as unknown as { WebSocket?: typeof WebSocket }).WebSocket;
+
+  document.body.innerHTML = '<div id="root"></div>';
+
+  global.WebSocket = jest.fn(() => ({
+    send: jest.fn(),
+    close: jest.fn(),
+    addEventListener: (ev: string, cb: (e: MessageEvent) => void) => {
+      if (ev === 'open') cb(new MessageEvent('open'));
+      if (ev === 'message')
+        cb(new MessageEvent('message', { data: JSON.stringify({ counts: lineCounts }) }));
+    },
+  })) as unknown as typeof WebSocket;
+
+  global.fetch = jest.fn((input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input instanceof Request
+        ? input.url
+        : '';
+    if (url.startsWith('/api/commits')) {
+      if (url.endsWith('/lines')) {
+        return Promise.resolve({ json: () => Promise.resolve({ counts: lineCounts }) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve({ commits }) });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  }) as jest.Mock;
+
+  return () => {
+    global.fetch = originalFetch;
+    if (originalWs) {
+      global.WebSocket = originalWs;
+    } else {
+      delete (global as unknown as { WebSocket?: unknown }).WebSocket;
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- add `setupAppTest` helper for DOM and API mocks
- use helper in App tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685052c1e528832ab3ec550ba7f76498