### PR TITLE
fix rotation variable usage

### DIFF
--- a/src/__tests__/components/fileCircle.rotation.test.tsx
+++ b/src/__tests__/components/fileCircle.rotation.test.tsx
@@ -36,4 +36,14 @@ describe('FileCircle rotation CSS variable', () => {
 
     expect(circle.style.getPropertyValue('--rotate')).toBe(`${Math.PI / 2}rad`);
   });
+
+  it('uses CSS variable for rotation transform', () => {
+    const { container } = render(
+      <FileCircle file="a" lines={1} radius={10} />,
+      { wrapper: Wrapper },
+    );
+    const circle = container.querySelector('.file-circle') as HTMLElement;
+
+    expect(circle.style.transform).toMatch(/rotate\(var\(--rotate\)\)/);
+  });
 });

--- a/src/client/components/FileCircle.tsx
+++ b/src/client/components/FileCircle.tsx
@@ -116,7 +116,7 @@ export const FileCircle = React.forwardRef<HTMLDivElement, FileCircleProps>(
           borderRadius: '50%',
           background: color,
           willChange: 'transform',
-          transform: `translate3d(${body.position.x - currentRadius}px, ${body.position.y - currentRadius}px, 0) rotate(${body.angle}rad)`,
+          transform: `translate3d(${body.position.x - currentRadius}px, ${body.position.y - currentRadius}px, 0) rotate(var(--rotate))`,
         } as React.CSSProperties}
       >
         <FileCircleContent


### PR DESCRIPTION
## Summary
- use CSS variable for element rotation
- test FileCircle transform uses `--rotate`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_685052a3eda8832aad9b41b08bb7289e