### PR TITLE
feat(server): centralize repo config

### DIFF
--- a/src/server/api-middleware.ts
+++ b/src/server/api-middleware.ts
@@ -3,9 +3,8 @@ import { z } from 'zod';
 import { appSettings } from './app-settings';
 import * as git from 'isomorphic-git';
 import fs from 'fs';
-import path from 'path';
 import { getLineCounts, getRenameMap } from './line-counts';
-import { defaultIgnore } from './ignore-defaults';
+import { resolveRepoDir, ignorePatterns } from './repo-config';
 import type {
   ApiError,
   CommitsResponse,
@@ -52,20 +51,6 @@ const resolveBranch = async (
 };
 
 export const apiMiddleware = express.Router();
-
-const repoDir = (app: express.Application): string =>
-  path.resolve((app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd());
-
-const resolveRepoDir = (app: express.Application): string => {
-  const dir = repoDir(app);
-  if (!fs.existsSync(path.join(dir, '.git'))) {
-    throw new Error(`${dir} is not a git repository.`);
-  }
-  return dir;
-};
-
-const ignorePatterns = (app: express.Application): string[] =>
-  (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [...defaultIgnore];
 
 apiMiddleware.get(
   '/api/commits',

--- a/src/server/repo-config.ts
+++ b/src/server/repo-config.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import path from 'path';
+import fs from 'fs';
+import { appSettings } from './app-settings';
+import { defaultIgnore } from './ignore-defaults';
+
+export const repoDir = (app: express.Application): string =>
+  path.resolve((app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd());
+
+export const resolveRepoDir = (app: express.Application): string => {
+  const dir = repoDir(app);
+  if (!fs.existsSync(path.join(dir, '.git'))) {
+    throw new Error(`${dir} is not a git repository.`);
+  }
+  return dir;
+};
+
+export const ignorePatterns = (app: express.Application): string[] =>
+  (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [...defaultIgnore];

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -3,12 +3,10 @@ import type WebSocket from 'ws';
 import type { Server, IncomingMessage } from 'http';
 import type { Socket } from 'node:net';
 import express from 'express';
-import path from 'path';
 import fs from 'fs';
 import * as git from 'isomorphic-git';
-import { appSettings } from './app-settings';
-import { defaultIgnore } from './ignore-defaults';
 import { getLineCounts, getRenameMap } from './line-counts';
+import { repoDir, ignorePatterns } from './repo-config';
 
 export interface LineCountsRequest {
   id: string;
@@ -41,11 +39,8 @@ export const setupLineCountWs = (app: express.Application, server: Server) => {
       next = null;
       processing = true;
       try {
-        const dir = path.resolve(
-          (app.get(appSettings.repo.description!) as string | undefined) ?? process.cwd(),
-        );
-        const ignore =
-          (app.get(appSettings.ignore.description!) as string[] | undefined) ?? [...defaultIgnore];
+        const dir = repoDir(app);
+        const ignore = ignorePatterns(app);
 
         await git.resolveRef({ fs, dir, ref: id });
         const parentId = previous ?? parent;


### PR DESCRIPTION
## Summary
- add `repo-config` module for shared helpers
- reuse helpers in API middleware and WebSocket server

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685053a2c914832aa3ec72006da24f20