### PR TITLE
Remove seekbar debug log

### DIFF
--- a/src/client/player.ts
+++ b/src/client/player.ts
@@ -55,7 +55,9 @@ export const createPlayer = ({
       lastTime = now();
       raf(tick);
     } else if (getSeek() >= end) {
-      console.log('[debug] seekbar final update processed at', getSeek());
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[debug] seekbar final update processed at', getSeek());
+      }
     }
     onPlayStateChange?.(playing);
   };


### PR DESCRIPTION
## Summary
- avoid unnecessary logging in the player helper

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505398e0cc832a8b579eac9ea1f6e1