### PR TITLE
Add unit tests for animations and engine runner

### DIFF
--- a/src/__tests__/fileCircleSimulation.test.tsx
+++ b/src/__tests__/fileCircleSimulation.test.tsx
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { FileCircleSimulation } from '../client/components/FileCircleSimulation';
+import type { LineCount } from '../client/types';
+
+describe('FileCircleSimulation', () => {
+  it('renders circles for files', () => {
+    const data: LineCount[] = [
+      { file: 'a', lines: 10, added: 0, removed: 0 },
+      { file: 'b', lines: 20, added: 0, removed: 0 },
+    ];
+    const { container } = render(<FileCircleSimulation data={data} />);
+    const div = container.firstChild as HTMLDivElement;
+
+    Object.defineProperty(div, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 100, height: 100, top: 0, left: 0, bottom: 0, right: 0 }),
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(container.querySelectorAll('.file-circle').length).toBe(2);
+  });
+});

--- a/src/__tests__/useAnimatedNumber.test.ts
+++ b/src/__tests__/useAnimatedNumber.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedNumber } from '../client/hooks/useAnimatedNumber';
+
+jest.useFakeTimers();
+
+describe('useAnimatedNumber', () => {
+  const originalRaf = global.requestAnimationFrame;
+  let now = 0;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    global.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      return setTimeout(() => {
+        now += 50;
+        cb(now);
+      }, 0) as unknown as number;
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    (performance.now as jest.Mock).mockRestore();
+    global.requestAnimationFrame = originalRaf;
+  });
+
+  it('animates toward the target', () => {
+    const { result } = renderHook(() => useAnimatedNumber(0, { duration: 100 }));
+
+    act(() => {
+      result.current[1](10);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(result.current[0]).toBeGreaterThan(5);
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    expect(result.current[0]).toBeCloseTo(10);
+  });
+
+  it('returns a stable animate function', () => {
+    const { result } = renderHook(() => useAnimatedNumber(0));
+    const animate = result.current[1];
+
+    act(() => {
+      result.current[1](5);
+      jest.advanceTimersByTime(150);
+    });
+
+    expect(result.current[1]).toBe(animate);
+  });
+});

--- a/src/__tests__/useEngineRunner.test.tsx
+++ b/src/__tests__/useEngineRunner.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useEngineRunner } from '../client/hooks/useEngineRunner';
+import * as engineHook from '../client/hooks/useEngine';
+import { Engine } from '../client/physics';
+
+describe('useEngineRunner', () => {
+  it('starts engine on mount and stops on unmount', () => {
+    const engine = new Engine();
+    jest.spyOn(engine, 'start').mockImplementation(() => undefined);
+    jest.spyOn(engine, 'stop').mockImplementation(() => undefined);
+    jest.spyOn(engineHook, 'useEngine').mockReturnValue(engine);
+
+    const Runner = () => {
+      useEngineRunner();
+      return null;
+    };
+
+    const { unmount } = render(<Runner />);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(engine.start).toHaveBeenCalled();
+
+    unmount();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(engine.stop).toHaveBeenCalled();
+
+    (engineHook.useEngine as jest.Mock).mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `useAnimatedNumber`
- add tests for `useEngineRunner`
- test basic rendering of `FileCircleSimulation`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_685055da6b58832a9e34b648bf568080