### PR TITLE
test: timers cleanup

### DIFF
--- a/src/__tests__/app/appAutoplay.test.tsx
+++ b/src/__tests__/app/appAutoplay.test.tsx
@@ -32,6 +32,7 @@ describe('App initial pause', () => {
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
     restore();
+    jest.useRealTimers();
   });
 
   it('does not advance timestamp automatically', async () => {

--- a/src/__tests__/app/appPlayPause.test.tsx
+++ b/src/__tests__/app/appPlayPause.test.tsx
@@ -32,6 +32,7 @@ describe('App play/pause', () => {
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
     restore();
+    jest.useRealTimers();
   });
 
   it('pauses and resumes playback when toggled', async () => {

--- a/src/__tests__/components/fileCircle.radius.test.tsx
+++ b/src/__tests__/components/fileCircle.radius.test.tsx
@@ -7,6 +7,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle radius effect', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
   );

--- a/src/__tests__/components/fileCircle.rotation.test.tsx
+++ b/src/__tests__/components/fileCircle.rotation.test.tsx
@@ -8,6 +8,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle rotation CSS variable', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   let engine: Engine | undefined;
   const CaptureEngine = () => {
     engine = useEngine();

--- a/src/__tests__/components/fileCircle.textSize.test.tsx
+++ b/src/__tests__/components/fileCircle.textSize.test.tsx
@@ -7,6 +7,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle text size', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
   );

--- a/src/__tests__/hooks/useCharEffectTimers.test.tsx
+++ b/src/__tests__/hooks/useCharEffectTimers.test.tsx
@@ -5,6 +5,12 @@ import { useCharEffectTimers } from '../../client/hooks/useCharEffectTimers';
 jest.useFakeTimers();
 
 describe('useCharEffectTimers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('calls the callback after the timeout', () => {
     const { result } = renderHook(() => useCharEffectTimers());
     const cb = jest.fn();

--- a/src/__tests__/hooks/useCountAnimation.test.tsx
+++ b/src/__tests__/hooks/useCountAnimation.test.tsx
@@ -23,6 +23,7 @@ describe('useCountAnimation', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
   });
 
   it('eases to the target within duration and rounds', () => {

--- a/src/__tests__/hooks/useRadiusAnimation.test.tsx
+++ b/src/__tests__/hooks/useRadiusAnimation.test.tsx
@@ -23,6 +23,7 @@ describe('useRadiusAnimation', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
   });
 
   it('eases to the target within duration', () => {

--- a/src/__tests__/hooks/useTimelineData.test.ts
+++ b/src/__tests__/hooks/useTimelineData.test.ts
@@ -8,6 +8,7 @@ describe('useTimelineData', () => {
   const originalWebSocket = global.WebSocket;
 
   afterEach(() => {
+    jest.useRealTimers();
     global.fetch = originalFetch;
     global.WebSocket = originalWebSocket;
   });

--- a/src/__tests__/hooks/useTypewriter.test.tsx
+++ b/src/__tests__/hooks/useTypewriter.test.tsx
@@ -5,6 +5,9 @@ import { useTypewriter } from '../../client/hooks/useTypewriter';
 jest.useFakeTimers();
 
 describe('useTypewriter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('animates when value changes', () => {
     const { result, rerender } = renderHook(
       ({ text }) => useTypewriter(text, 50),


### PR DESCRIPTION
## Summary
- restore real timers after jest fake timers tests
- ensure hooks using fake timers reset them properly

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685055dfbb60832a853eb1063cc17efc