### PR TITLE
Ensure timers reset after each test

### DIFF
--- a/src/__tests__/app/appAutoplay.test.tsx
+++ b/src/__tests__/app/appAutoplay.test.tsx
@@ -31,6 +31,7 @@ describe('App initial pause', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
     restore();
   });
 

--- a/src/__tests__/app/appPlayPause.test.tsx
+++ b/src/__tests__/app/appPlayPause.test.tsx
@@ -31,6 +31,7 @@ describe('App play/pause', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
     restore();
   });
 

--- a/src/__tests__/components/fileCircle.radius.test.tsx
+++ b/src/__tests__/components/fileCircle.radius.test.tsx
@@ -7,6 +7,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle radius effect', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
   );

--- a/src/__tests__/components/fileCircle.rotation.test.tsx
+++ b/src/__tests__/components/fileCircle.rotation.test.tsx
@@ -8,6 +8,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle rotation CSS variable', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   let engine: Engine | undefined;
   const CaptureEngine = () => {
     engine = useEngine();

--- a/src/__tests__/components/fileCircle.textSize.test.tsx
+++ b/src/__tests__/components/fileCircle.textSize.test.tsx
@@ -7,6 +7,9 @@ import { FileCircle } from '../../client/components/FileCircle';
 jest.useFakeTimers();
 
 describe('FileCircle text size', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
   );

--- a/src/__tests__/hooks/useCharEffectTimers.test.tsx
+++ b/src/__tests__/hooks/useCharEffectTimers.test.tsx
@@ -5,6 +5,9 @@ import { useCharEffectTimers } from '../../client/hooks/useCharEffectTimers';
 jest.useFakeTimers();
 
 describe('useCharEffectTimers', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('calls the callback after the timeout', () => {
     const { result } = renderHook(() => useCharEffectTimers());
     const cb = jest.fn();

--- a/src/__tests__/hooks/useCountAnimation.test.tsx
+++ b/src/__tests__/hooks/useCountAnimation.test.tsx
@@ -23,6 +23,7 @@ describe('useCountAnimation', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
   });
 
   it('eases to the target within duration and rounds', () => {

--- a/src/__tests__/hooks/useRadiusAnimation.test.tsx
+++ b/src/__tests__/hooks/useRadiusAnimation.test.tsx
@@ -23,6 +23,7 @@ describe('useRadiusAnimation', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
   });
 
   it('eases to the target within duration', () => {

--- a/src/__tests__/hooks/useTimelineData.reconnect.test.ts
+++ b/src/__tests__/hooks/useTimelineData.reconnect.test.ts
@@ -10,6 +10,7 @@ describe('useTimelineData', () => {
   afterEach(() => {
     global.fetch = originalFetch;
     global.WebSocket = originalWebSocket;
+    jest.useRealTimers();
   });
 
   it('reconnects and resends the current commit', async () => {

--- a/src/__tests__/hooks/useTypewriter.test.tsx
+++ b/src/__tests__/hooks/useTypewriter.test.tsx
@@ -5,6 +5,9 @@ import { useTypewriter } from '../../client/hooks/useTypewriter';
 jest.useFakeTimers();
 
 describe('useTypewriter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('animates when value changes', () => {
     const { result, rerender } = renderHook(
       ({ text }) => useTypewriter(text, 50),

--- a/src/__tests__/useAnimatedNumber.test.ts
+++ b/src/__tests__/useAnimatedNumber.test.ts
@@ -23,6 +23,7 @@ describe('useAnimatedNumber', () => {
     jest.clearAllTimers();
     (performance.now as jest.Mock).mockRestore();
     global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
   });
 
   it('animates toward the target', () => {


### PR DESCRIPTION
## Summary
- reset Jest timers after tests that run `jest.useFakeTimers`

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850577e9638832a909de4e81a507410