### PR TITLE
codex/drop-js-extension-imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ export default {
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    '^../server/(.*)$': '<rootDir>/src/server/$1.ts',
+    '^(?:\\.{2}/)+server/(.*)$': '<rootDir>/src/server/$1.ts',
   },
   testMatch: ['**/__tests__/**/*.test.ts?(x)'],
   testTimeout: 10000,

--- a/src/__tests__/server/lineCounts.test.ts
+++ b/src/__tests__/server/lineCounts.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as git from 'isomorphic-git';
-import { getLineCounts, getRenameMap } from '../../server/line-counts.js';
+import { getLineCounts, getRenameMap } from '../../server/line-counts';
 import { defaultIgnore } from '../../server/ignore-defaults';
 
 const author = { name: 'a', email: 'a@example.com' };


### PR DESCRIPTION
## Summary
- fix server test import paths without `.js` extension
- map server modules via jest `moduleNameMapper`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505ac75d98832aa3cbb88e5626768f