### PR TITLE
Update CI workflow timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3
@@ -21,12 +22,25 @@ jobs:
         timeout-minutes: 5
       - run: npm run typecheck
       - run: npm run lint
-      - run: npm test
+      - run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
       - uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-playwright-
       - run: npx playwright install --with-deps
-      - run: npm run build
+      - run: npm test
       - run: npm run test:playwright


### PR DESCRIPTION
## Summary
- set explicit timeouts for build and test jobs
- keep lint/test/build steps in CI

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505fb617e4832a9b479c9b53cb663d