### PR TITLE
Add screenshot docs and ensure output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ npm run test:playwright
 ```
 Playwright tests live in the `playwright` directory.
 
+## Screenshots
+
+Generate a timeline screenshot once the server is running:
+
+```bash
+npx tsx scripts/capture-timeline-mid.ts
+```
+The image is saved to `docs/timeline-mid.png`.
+
 ## Attribution
 
 All code in this project was written by Codex.

--- a/scripts/capture-timeline-mid.ts
+++ b/scripts/capture-timeline-mid.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { mkdirSync } from 'fs';
 import { chromium } from 'playwright';
 
 async function startServer(): Promise<() => void> {
@@ -35,6 +36,7 @@ void (async (): Promise<void> => {
   }, midTimestamp);
 
   await page.waitForTimeout(3000);
+  mkdirSync('docs', { recursive: true });
   const buf = await page.screenshot({ path: 'docs/timeline-mid.png' });
   console.log(buf.toString('base64'));
 


### PR DESCRIPTION
## Summary
- create placeholder docs directory
- ensure `capture-timeline-mid.ts` creates the `docs` folder
- document screenshot generation steps

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850e9b703d8832a8ee057ebbfe8ee98