### PR TITLE
Add tests for resource caching

### DIFF
--- a/src/__tests__/client/commitsResource.test.ts
+++ b/src/__tests__/client/commitsResource.test.ts
@@ -1,0 +1,61 @@
+jest.mock('../../client/api', () => ({
+  fetchCommits: jest.fn(),
+}));
+
+describe('commitsResource', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('caches commits per base URL', async () => {
+    const { fetchCommits } = await import('../../client/api');
+    const mockFetch = fetchCommits as jest.MockedFunction<typeof fetchCommits>;
+    mockFetch.mockResolvedValue([{ id: 'a', message: 'm', timestamp: 1 }]);
+
+    const { readCommits } = await import('../../client/commitsResource');
+
+    let thrown: unknown;
+    try {
+      readCommits('/base');
+    } catch (e) {
+      thrown = e;
+    }
+    await (thrown as Promise<unknown>);
+
+    const first = readCommits('/base');
+    const second = readCommits('/base');
+
+    expect(second).toBe(first);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('separates caches for different base URLs', async () => {
+    const { fetchCommits } = await import('../../client/api');
+    const mockFetch = fetchCommits as jest.MockedFunction<typeof fetchCommits>;
+    mockFetch
+      .mockResolvedValueOnce([{ id: 'a', message: 'm', timestamp: 1 }])
+      .mockResolvedValueOnce([{ id: 'b', message: 'n', timestamp: 2 }]);
+
+    const { readCommits } = await import('../../client/commitsResource');
+
+    let p1: unknown;
+    try {
+      readCommits('/one');
+    } catch (e) {
+      p1 = e;
+    }
+    await (p1 as Promise<unknown>);
+    readCommits('/one');
+
+    let p2: unknown;
+    try {
+      readCommits('/two');
+    } catch (e) {
+      p2 = e;
+    }
+    await (p2 as Promise<unknown>);
+    readCommits('/two');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/client/createResource.test.ts
+++ b/src/__tests__/client/createResource.test.ts
@@ -1,0 +1,61 @@
+import { createResource } from '../../client/resource';
+
+describe('createResource', () => {
+  it('throws the promise while pending', () => {
+    let resolve: (v: number) => void;
+    const p = new Promise<number>((r) => {
+      resolve = r;
+    });
+    const read = createResource(() => p);
+
+    let first: unknown;
+    let second: unknown;
+    try {
+      read();
+    } catch (e) {
+      first = e;
+    }
+    try {
+      read();
+    } catch (e) {
+      second = e;
+    }
+
+    expect(first).toBe(second);
+    expect(first).toBeInstanceOf(Promise);
+
+    resolve!(1);
+  });
+
+  it('returns resolved value', async () => {
+    let resolve: (v: number) => void;
+    const p = new Promise<number>((r) => {
+      resolve = r;
+    });
+    const read = createResource(() => p);
+    try {
+      read();
+    } catch {
+      // ignore thrown promise
+    }
+    resolve!(42);
+    await p;
+    expect(read()).toBe(42);
+  });
+
+  it('rethrows errors as Error', async () => {
+    let reject: (err: unknown) => void;
+    const p = new Promise<unknown>((_, r) => {
+      reject = r;
+    });
+    const read = createResource(() => p);
+    try {
+      read();
+    } catch {
+      // ignore thrown promise
+    }
+    reject!('boom');
+    await p.catch(() => {});
+    expect(() => read()).toThrow(Error);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `createResource`
- ensure commitsResource caches by URL

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ec1b0028832abe679e32e53ccc38