### PR TITLE
Improve useBody update effect

### DIFF
--- a/src/__tests__/hooks/useBody.test.tsx
+++ b/src/__tests__/hooks/useBody.test.tsx
@@ -42,4 +42,24 @@ describe('useBody', () => {
     expect(result.current.body.position.x).toBeGreaterThanOrEqual(10);
     expect(result.current.body.position.x).toBeLessThanOrEqual(190);
   });
+
+  it('keeps body.onUpdate stable when options object changes', () => {
+    const onUpdate = jest.fn();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PhysicsProvider bounds={{ width: 100, height: 100 }}>{children}</PhysicsProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      ({ options }: { options: Parameters<typeof useBody>[0] }) => {
+        const engine = useEngine();
+        const info = useBody(options);
+        return { engine, ...info };
+      },
+      { wrapper, initialProps: { options: { radius: 10, onUpdate } } },
+    );
+
+    const initialOnUpdate = result.current.body.onUpdate;
+    rerender({ options: { radius: 10, onUpdate } });
+    expect(result.current.body.onUpdate).toBe(initialOnUpdate);
+  });
 });

--- a/src/client/hooks/useBody.ts
+++ b/src/client/hooks/useBody.ts
@@ -12,7 +12,13 @@ interface BodyOptions {
 
 export const useBody = (options: BodyOptions) => {
   const engine = useEngine();
-  const { radius, restitution = 0, frictionAir = 0, friction = 0 } = options;
+  const {
+    radius,
+    restitution = 0,
+    frictionAir = 0,
+    friction = 0,
+    onUpdate,
+  } = options;
 
   const [, setTransform] = useState(() => ({
     position: { x: 0, y: 0 },
@@ -33,9 +39,9 @@ export const useBody = (options: BodyOptions) => {
   useEffect(() => {
     body.onUpdate = () => {
       setTransform({ position: { ...body.position }, angle: body.angle });
-      options.onUpdate?.(body);
+      onUpdate?.(body);
     };
-  }, [body, options]);
+  }, [body, onUpdate]);
 
   useEffect(() => {
     engine.add(body);


### PR DESCRIPTION
## Summary
- destructure `onUpdate` in `useBody`
- ensure effect only depends on `onUpdate`
- test effect stability

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_6850fc8be22c832ab4c6b84df815e07d