### PR TITLE
Add reconnection on WebSocket error

### DIFF
--- a/src/__tests__/hooks/useTimelineData.reconnect.test.ts
+++ b/src/__tests__/hooks/useTimelineData.reconnect.test.ts
@@ -92,4 +92,84 @@ describe('useTimelineData', () => {
     };
     expect(secondSend.id).toBe('c2');
   });
+
+  it('reconnects on socket error event', async () => {
+    jest.useFakeTimers();
+    const commits = [
+      { id: 'c1', message: 'a', timestamp: 2 },
+      { id: 'c2', message: 'b', timestamp: 1 },
+    ];
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input instanceof Request
+              ? input.url
+              : '';
+      if (url.startsWith('/reconnect/api/commits')) {
+        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
+      }
+      return Promise.reject(new Error(`unexpected ${url}`));
+    }) as unknown as typeof fetch;
+
+    const sockets: Array<{
+      send: jest.Mock<void, [string]>;
+      triggerError: () => void;
+      triggerOpen: () => void;
+    }> = [];
+    global.WebSocket = jest.fn(() => {
+      let errorHandler: (() => void) | undefined;
+      let openHandler: (() => void) | undefined;
+      const send = jest.fn() as jest.Mock<void, [string]>;
+      const socket = {
+        readyState: 1,
+        send,
+        close: jest.fn(),
+        addEventListener: (ev: string, cb: (e: Event) => void) => {
+          if (ev === 'open') openHandler = () => cb(new Event('open'));
+          if (ev === 'error') errorHandler = () => cb(new Event('error'));
+        },
+      } as unknown as WebSocket;
+      sockets.push({
+        send,
+        triggerError: () => errorHandler?.(),
+        triggerOpen: () => openHandler?.(),
+      });
+      setTimeout(() => openHandler?.(), 0);
+      return socket;
+    }) as unknown as typeof WebSocket;
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Suspense, { fallback: 'loading' }, children);
+
+    renderHook(
+      () => useTimelineData({ timestamp: 0, baseUrl: '/reconnect' }),
+      { wrapper },
+    );
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    await waitFor(() => expect(sockets.length).toBe(1));
+    const first = sockets[0];
+    if (!first) throw new Error('first socket');
+    const firstSend = JSON.parse(first.send.mock.calls[0]![0]) as { id: string };
+    expect(firstSend.id).toBe('c2');
+
+    act(() => {
+      first.triggerError();
+      jest.advanceTimersByTime(1000);
+      jest.runOnlyPendingTimers();
+    });
+
+    await waitFor(() => expect(sockets.length).toBe(2));
+    const second = sockets[1];
+    if (!second) throw new Error('second socket');
+    const secondSend = JSON.parse(second.send.mock.calls[0]![0]) as {
+      id: string;
+    };
+    expect(secondSend.id).toBe('c2');
+  });
 });

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -73,6 +73,12 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
         reconnectRef.current = setTimeout(connect, 1000);
       }
     });
+    socket.addEventListener('error', () => {
+      socketRef.current = null;
+      if (activeRef.current) {
+        reconnectRef.current = setTimeout(connect, 1000);
+      }
+    });
     socketRef.current = socket;
   }, [baseUrl, handleMessage, sendCurrent]);
 


### PR DESCRIPTION
## Summary
- reconnect when WebSocket emits `error`
- test reconnection on `error` event

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_6850fc86a478832a9a670409181f976c