### PR TITLE
Add angular velocity damping

### DIFF
--- a/src/__tests__/app/engineAngularDamping.test.ts
+++ b/src/__tests__/app/engineAngularDamping.test.ts
@@ -1,0 +1,16 @@
+/** @jest-environment jsdom */
+import { Engine, Body } from '../../client/physics';
+
+describe('Engine angular damping', () => {
+  it('reduces angular velocity over time', () => {
+    const engine = new Engine(200, 100);
+    engine.gravity.y = 0;
+    const body = new Body({ position: { x: 50, y: 50 }, radius: 10, angularDamping: 0.001 });
+    body.angularVelocity = 1;
+    engine.add(body);
+
+    for (let i = 0; i < 60; i += 1) engine.update(16);
+
+    expect(body.angularVelocity).toBeLessThan(1);
+  });
+});

--- a/src/client/hooks/useBody.ts
+++ b/src/client/hooks/useBody.ts
@@ -7,6 +7,7 @@ interface BodyOptions {
   restitution?: number;
   frictionAir?: number;
   friction?: number;
+  angularDamping?: number;
   onUpdate?: (body: Physics.Body) => void;
 }
 
@@ -17,6 +18,7 @@ export const useBody = (options: BodyOptions) => {
     restitution = 0,
     frictionAir = 0,
     friction = 0,
+    angularDamping = 0,
     onUpdate,
   } = options;
 
@@ -30,7 +32,7 @@ export const useBody = (options: BodyOptions) => {
       Math.random() * (engine.bounds.width - radius * 2) + radius,
       -radius,
       radius,
-      { restitution, frictionAir, friction },
+      { restitution, frictionAir, friction, angularDamping },
     );
     setTransform({ position: { ...b.position }, angle: b.angle });
     return b;

--- a/src/client/physics.ts
+++ b/src/client/physics.ts
@@ -24,6 +24,7 @@ export class Body {
   restitution: number;
   friction: number;
   frictionAir: number;
+  angularDamping: number;
   mass: number;
   radius?: number;
   aabb: AABB;
@@ -36,6 +37,7 @@ export class Body {
     radius?: number;
     friction?: number;
     frictionAir?: number;
+    angularDamping?: number;
     mass?: number;
     onUpdate?: (body: Body) => void;
   }) {
@@ -46,6 +48,7 @@ export class Body {
     this.restitution = opts.restitution ?? 1;
     this.friction = opts.friction ?? 0;
     this.frictionAir = opts.frictionAir ?? 0;
+    this.angularDamping = opts.angularDamping ?? 0;
     this.mass = opts.mass ?? 1;
     if (opts.radius !== undefined) this.radius = opts.radius;
     if (opts.onUpdate) this.onUpdate = opts.onUpdate;
@@ -206,6 +209,7 @@ export class Engine {
         restitution: number;
         frictionAir: number;
         friction: number;
+        angularDamping: number;
         mass: number;
       }
     > = {},
@@ -218,6 +222,8 @@ export class Engine {
     if (opts.friction !== undefined) params.friction = opts.friction;
     if (opts.frictionAir !== undefined) params.frictionAir = opts.frictionAir;
     if (opts.mass !== undefined) params.mass = opts.mass;
+    if (opts.angularDamping !== undefined)
+      params.angularDamping = opts.angularDamping;
     if (opts.onUpdate) params.onUpdate = opts.onUpdate;
     return new Body(params);
   }
@@ -255,6 +261,8 @@ export class Engine {
       body.velocity.x *= air;
       body.velocity.y *= air;
       body.angularVelocity *= air;
+      if (body.angularDamping)
+        body.angularVelocity *= Math.exp(-body.angularDamping * dt);
 
       if (body.radius !== undefined) {
         if (body.position.x - body.radius < 0) {


### PR DESCRIPTION
## Summary
- add `angularDamping` property to `Body`
- pass `angularDamping` through `Engine.circle` and `useBody`
- decay angular velocity each update
- test angular velocity damping

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685103f60284832a9e541f3c168eba7c