### PR TITLE
Add extra hook tests

### DIFF
--- a/src/__tests__/hooks/useAnimatedNumber.round.test.tsx
+++ b/src/__tests__/hooks/useAnimatedNumber.round.test.tsx
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useAnimatedNumber } from '../../client/hooks/useAnimatedNumber';
+
+describe('useAnimatedNumber extra tests', () => {
+  const originalRaf = global.requestAnimationFrame;
+  const originalCancel = global.cancelAnimationFrame;
+  let now = 0;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    global.requestAnimationFrame = (cb: FrameRequestCallback) =>
+      setTimeout(() => {
+        now += 50;
+        cb(now);
+      }, 0) as unknown as number;
+    global.cancelAnimationFrame = jest.fn(id => clearTimeout(id as unknown as number));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    (performance.now as jest.Mock).mockRestore();
+    global.requestAnimationFrame = originalRaf;
+    global.cancelAnimationFrame = originalCancel;
+    jest.useRealTimers();
+  });
+
+  it('rounds values when enabled', () => {
+    const { result } = renderHook(() =>
+      useAnimatedNumber(0, { duration: 100, round: true }),
+    );
+
+    act(() => {
+      result.current[1](5);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(Number.isInteger(result.current[0])).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(60);
+    });
+    expect(result.current[0]).toBe(5);
+  });
+
+  it('cancels animation on unmount', () => {
+    const { result, unmount } = renderHook(() =>
+      useAnimatedNumber(0, { duration: 100 }),
+    );
+
+    act(() => {
+      result.current[1](5);
+    });
+
+    unmount();
+    expect(global.cancelAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useGlowAnimation.deps.test.ts
+++ b/src/__tests__/hooks/useGlowAnimation.deps.test.ts
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import { useGlowAnimation } from '../../client/hooks/useGlowAnimation';
+
+describe('useGlowAnimation dependencies', () => {
+  it('keeps callbacks stable when deps do not change', () => {
+    const { result, rerender } = renderHook(({d}) => useGlowAnimation([d]), {
+      initialProps: { d: 1 },
+    });
+    const start = result.current[0];
+    const end = result.current[1].onAnimationEnd;
+    rerender({ d: 1 });
+    expect(result.current[0]).toBe(start);
+    expect(result.current[1].onAnimationEnd).toBe(end);
+  });
+
+  it('updates callbacks when deps change', () => {
+    const { result, rerender } = renderHook(({d}) => useGlowAnimation([d]), {
+      initialProps: { d: 1 },
+    });
+    const start = result.current[0];
+    rerender({ d: 2 });
+    expect(result.current[0]).not.toBe(start);
+  });
+});

--- a/src/__tests__/hooks/useSize.cleanup.test.tsx
+++ b/src/__tests__/hooks/useSize.cleanup.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { useSize } from '../../client/hooks/useSize';
+
+describe('useSize cleanup', () => {
+  it('removes resize listener on unmount', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    function Component() {
+      const { ref } = useSize<HTMLDivElement>();
+      return (
+        // eslint-disable-next-line no-restricted-syntax
+        <div ref={ref}></div>
+      );
+    }
+
+    const { unmount } = render(<Component />);
+    const handler = addSpy.mock.calls.find(c => c[0] === 'resize')?.[1] as EventListener;
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+  });
+
+  it('handles missing bounding rect', () => {
+    function Component() {
+      const { ref, size } = useSize<HTMLDivElement>();
+      return (
+        // eslint-disable-next-line no-restricted-syntax
+        <div ref={ref} data-w={size.width} data-h={size.height}></div>
+      );
+    }
+    const { container } = render(<Component />);
+    const div = container.firstChild as HTMLDivElement;
+    Object.defineProperty(div, 'getBoundingClientRect', { value: () => undefined });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(div.dataset.w).toBe('0');
+    expect(div.dataset.h).toBe('0');
+  });
+});


### PR DESCRIPTION
## Summary
- extend coverage for `useAnimatedNumber` rounding and cancellation
- test callback stability for `useGlowAnimation`
- check cleanup for `useSize`

## Testing
- `npm run lint`
- `npm test --coverage`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68512531f0a8832aa282a4ebc62dedbe