### PR TITLE
Merge commit range into lineCounts websocket

### DIFF
--- a/src/__tests__/server/wsCommits.test.ts
+++ b/src/__tests__/server/wsCommits.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as git from 'isomorphic-git';
+import express from 'express';
+import { createServer } from 'http';
+import type { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import { appSettings } from '../../server/app-settings';
+import { setupLineCountWs } from '../../server/ws';
+
+const author = { name: 'a', email: 'a@example.com' };
+
+describe('setupLineCountWs commit range', () => {
+  it('sends commits around given id', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    const app = express();
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    const server = createServer(app);
+    try {
+      await git.init({ fs, dir });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'first' });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '2');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'second' });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '3');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'third' });
+      const logs = await git.log({ fs, dir, ref: 'HEAD', depth: 3 });
+      const middle = logs[1]!.oid;
+      app.set(appSettings.repo.description!, dir);
+      app.set(appSettings.branch.description!, 'HEAD');
+      setupLineCountWs(app, server);
+      await new Promise<void>((resolve) => server.listen(0, resolve));
+      const { port } = server.address() as AddressInfo;
+      await expect(
+        new Promise<string[]>((resolve, reject) => {
+          const ws = new WebSocket(`ws://localhost:${port}/ws/lines`);
+          ws.on('open', () => {
+            ws.send(JSON.stringify({ id: middle }));
+          });
+          ws.on('message', (d) => {
+            const text =
+              typeof d === 'string'
+                ? d
+                : Array.isArray(d)
+                  ? Buffer.concat(d).toString('utf8')
+                  : Buffer.from(d).toString('utf8');
+            const data = JSON.parse(text) as { commits: Array<{ id: string }> };
+            resolve(data.commits.map((c) => c.id));
+          });
+          ws.on('error', reject);
+        })
+      ).resolves.toEqual(logs.map((l) => l.oid));
+    } finally {
+      server.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -10,6 +10,7 @@ export interface CommitsResponse {
 
 export interface LineCountsResponse {
   counts: LineCount[];
+  commits: Commit[];
   renames?: Record<string, string> | undefined;
   token?: number | undefined;
 }

--- a/src/server/api-middleware.ts
+++ b/src/server/api-middleware.ts
@@ -30,6 +30,7 @@ const commitsResponseSchema = z.object({
 
 const lineCountsResponseSchema = z.object({
   counts: z.array(lineCountSchema),
+  commits: z.array(commitSchema),
   renames: z.record(z.string(), z.string()).optional(),
 });
 
@@ -128,7 +129,7 @@ apiMiddleware.get(
             ignore,
           })
         : undefined;
-      const payload = renames ? { counts, renames } : { counts };
+      const payload = renames ? { counts, renames, commits: [] } : { counts, commits: [] };
       const parsed = lineCountsResponseSchema.safeParse(payload);
       if (!parsed.success) {
         res.status(500).json({ error: 'Invalid data' });


### PR DESCRIPTION
## Summary
- simplify commit range API by removing request parameters
- return surrounding commits when fetching line counts via WebSocket
- update server test to reflect new API
- make commit range required in response types

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_685159c0ca04832a9fb5746ad442863c