### PR TITLE
feat(ws): use websocket commit data

### DIFF
--- a/src/__tests__/app/appFetchCalls.test.tsx
+++ b/src/__tests__/app/appFetchCalls.test.tsx
@@ -21,25 +21,15 @@ describe('App API calls', () => {
     restore();
   });
 
-  it('fetches commits once and lines on timestamp change', async () => {
+  it('does not fetch commits and uses WebSocket for lines', async () => {
     const { container } = render(<App />);
     await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
     const fetchMock = global.fetch as jest.Mock;
-    expect(
-      fetchMock.mock.calls.filter(
-        ([u]) => typeof u === 'string' && u.startsWith('/api/commits') && !u.includes('/lines'),
-      ),
-    ).toHaveLength(1);
-    expect(fetchMock.mock.calls.some(([u]) => typeof u === 'string' && u.includes('/lines'))).toBe(false);
+    expect(fetchMock.mock.calls).toHaveLength(0);
 
     const input = container.querySelector('input[type="range"]') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '1500' } });
 
-    await waitFor(() => expect(fetchMock.mock.calls.length).toBe(1));
-    expect(
-      fetchMock.mock.calls.filter(
-        ([u]) => typeof u === 'string' && u.startsWith('/api/commits') && !u.includes('/lines'),
-      ),
-    ).toHaveLength(1);
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBe(0));
   });
 });

--- a/src/__tests__/helpers/app.ts
+++ b/src/__tests__/helpers/app.ts
@@ -27,27 +27,11 @@ export const setupAppTest = (
     addEventListener: (ev: string, cb: (e: MessageEvent) => void) => {
       if (ev === 'open') cb(new MessageEvent('open'));
       if (ev === 'message')
-        cb(new MessageEvent('message', { data: JSON.stringify({ counts: lineCounts }) }));
+        cb(new MessageEvent('message', { data: JSON.stringify({ counts: lineCounts, commits }) }));
     },
   })) as unknown as typeof WebSocket;
 
-  global.fetch = jest.fn((input: RequestInfo | URL) => {
-    const url =
-      typeof input === 'string'
-        ? input
-        : input instanceof URL
-        ? input.href
-        : input instanceof Request
-        ? input.url
-        : '';
-    if (url.startsWith('/api/commits')) {
-      if (url.endsWith('/lines')) {
-        return Promise.resolve({ json: () => Promise.resolve({ counts: lineCounts }) });
-      }
-      return Promise.resolve({ json: () => Promise.resolve({ commits }) });
-    }
-    return Promise.reject(new Error(`Unexpected url: ${url}`));
-  }) as jest.Mock;
+  global.fetch = jest.fn(() => Promise.reject(new Error('Unexpected fetch')));
 
   return () => {
     global.fetch = originalFetch;

--- a/src/__tests__/hooks/useTimelineData.fetch.test.ts
+++ b/src/__tests__/hooks/useTimelineData.fetch.test.ts
@@ -12,27 +12,14 @@ describe('useTimelineData', () => {
     global.WebSocket = originalWebSocket;
   });
 
-  it('fetches commits and line counts', async () => {
+  it('receives commits and line counts via WebSocket', async () => {
     const commits = [
       { id: 'c1', message: 'a', timestamp: 2 },
       { id: 'c2', message: 'b', timestamp: 1 },
     ];
     const linesFirst = [{ file: 'a', lines: 1, added: 0, removed: 0 }];
     const linesSecond = [{ file: 'a', lines: 2, added: 1, removed: 0 }];
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      if (url.startsWith('/basic/api/commits')) {
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
-      }
-      return Promise.reject(new Error(`unexpected ${url}`));
-    }) as unknown as typeof fetch;
+    global.fetch = jest.fn(() => Promise.reject(new Error('unexpected fetch')));
 
     let messageHandler: ((ev: MessageEvent) => void) | undefined;
     global.WebSocket = jest.fn(() => {
@@ -40,10 +27,16 @@ describe('useTimelineData', () => {
         readyState: 1,
         send: jest.fn((data: string) => {
           const { id, token } = JSON.parse(data) as { id: string; token: number };
-          const counts = id === 'c2' ? linesFirst : linesSecond;
-          messageHandler?.(
-            new MessageEvent('message', { data: JSON.stringify({ counts, token }) }),
-          );
+          if (id === 'HEAD') {
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ counts: linesSecond, commits, token }) }),
+            );
+          } else {
+            const counts = id === 'c2' ? linesFirst : linesSecond;
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ counts, token }) }),
+            );
+          }
         }),
         close: jest.fn(),
         addEventListener: (ev: string, cb: (e: MessageEvent) => void) => {
@@ -77,12 +70,6 @@ describe('useTimelineData', () => {
       expect(result.current.lineCounts).toEqual(linesSecond),
     );
 
-    const calls = (global.fetch as jest.Mock).mock.calls;
-    expect(
-      calls.filter(
-        ([u]) => typeof u === 'string' && u.startsWith(`${base}/api/commits`) && !u.includes('/lines'),
-      ).length,
-    ).toBe(1);
-    expect(calls).toHaveLength(1);
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(0);
   });
 });

--- a/src/__tests__/hooks/useTimelineData.reconnect.test.ts
+++ b/src/__tests__/hooks/useTimelineData.reconnect.test.ts
@@ -15,24 +15,7 @@ describe('useTimelineData', () => {
 
   it('reconnects and resends the current commit', async () => {
     jest.useFakeTimers();
-    const commits = [
-      { id: 'c1', message: 'a', timestamp: 2 },
-      { id: 'c2', message: 'b', timestamp: 1 },
-    ];
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      if (url.startsWith('/reconnect/api/commits')) {
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
-      }
-      return Promise.reject(new Error(`unexpected ${url}`));
-    }) as unknown as typeof fetch;
+    global.fetch = jest.fn(() => Promise.reject(new Error('unexpected fetch')));
 
     const sockets: Array<{
       send: jest.Mock<void, [string]>;
@@ -93,24 +76,7 @@ describe('useTimelineData', () => {
 
   it('reconnects on socket error event', async () => {
     jest.useFakeTimers();
-    const commits = [
-      { id: 'c1', message: 'a', timestamp: 2 },
-      { id: 'c2', message: 'b', timestamp: 1 },
-    ];
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input instanceof Request
-              ? input.url
-              : '';
-      if (url.startsWith('/reconnect/api/commits')) {
-        return Promise.resolve({ json: () => Promise.resolve({ commits }) } as unknown as Response);
-      }
-      return Promise.reject(new Error(`unexpected ${url}`));
-    }) as unknown as typeof fetch;
+    global.fetch = jest.fn(() => Promise.reject(new Error('unexpected fetch')));
 
     const sockets: Array<{
       send: jest.Mock<void, [string]>;

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -15,7 +15,7 @@ export interface LineCountsRequest {
   token?: number;
 }
 
-const COMMITS_AROUND = 1;
+const COMMITS_AROUND = 15;
 
 export const setupLineCountWs = (app: express.Application, server: Server) => {
   const wss = new WebSocketServer({ noServer: true });


### PR DESCRIPTION
## Summary
- rely on websocket messages for commit history
- adjust commit range on the server
- update tests to match websocket logic

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516737b8c4832ab1b06e53219ce3e3