### PR TITLE
feat: websocket range updates

### DIFF
--- a/src/__tests__/app/appPlayPause.test.tsx
+++ b/src/__tests__/app/appPlayPause.test.tsx
@@ -37,10 +37,13 @@ describe('App play/pause', () => {
 
   it('pauses and resumes playback when toggled', async () => {
     const { container } = render(<App />);
-    await waitFor(() => expect(container.querySelector('#commit-log')).toBeTruthy());
+    await waitFor(() =>
+      expect(container.querySelectorAll('#commit-log li').length).toBeGreaterThan(0),
+    );
 
     const input = container.querySelector('input[type="range"]') as HTMLInputElement;
     const button = container.querySelector('#controls button') as HTMLButtonElement;
+    await waitFor(() => expect(button.disabled).toBe(false));
     const initial = Number(input.value);
 
     act(() => {

--- a/src/__tests__/app/lines.test.ts
+++ b/src/__tests__/app/lines.test.ts
@@ -17,7 +17,11 @@ describe('lines module', () => {
       addEventListener: (event: string, cb: (ev: MessageEvent) => void) => {
         if (event === 'open') cb(new MessageEvent('open'));
         if (event === 'message')
-          cb(new MessageEvent('message', { data: JSON.stringify({ counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }] }) }));
+          cb(
+            new MessageEvent('message', {
+              data: JSON.stringify({ type: 'data', counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }], commits: [] }),
+            }),
+          );
       },
     } as unknown as WebSocket;
     global.WebSocket = jest.fn(() => socket) as unknown as typeof WebSocket;
@@ -34,7 +38,7 @@ describe('lines module', () => {
       close: jest.fn(),
       addEventListener: (event: string, cb: (ev: MessageEvent) => void) => {
         if (event === 'open') cb(new MessageEvent('open'));
-        if (event === 'message') cb(new MessageEvent('message', { data: JSON.stringify({ counts: [] }) }));
+        if (event === 'message') cb(new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: [], commits: [] }) }));
       },
     } as unknown as WebSocket;
     global.WebSocket = jest.fn(() => socket) as unknown as typeof WebSocket;

--- a/src/__tests__/hooks/useTimelineData.dedup.test.ts
+++ b/src/__tests__/hooks/useTimelineData.dedup.test.ts
@@ -27,15 +27,26 @@ describe('useTimelineData', () => {
       if (id === 'HEAD') {
         messageHandler?.(
           new MessageEvent('message', {
-            data: JSON.stringify({ counts: linesSecond, commits, token }),
+            data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
           }),
+        );
+        messageHandler?.(
+          new MessageEvent('message', {
+            data: JSON.stringify({ type: 'data', counts: linesSecond, commits, token }),
+          }),
+        );
+        messageHandler?.(
+          new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
         );
       } else {
         const counts = id === 'c2' ? linesFirst : linesSecond;
         messageHandler?.(
           new MessageEvent('message', {
-            data: JSON.stringify({ counts, token }),
+            data: JSON.stringify({ type: 'data', counts, token, commits: [] }),
           }),
+        );
+        messageHandler?.(
+          new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
         );
       }
     });

--- a/src/__tests__/hooks/useTimelineData.fetch.test.ts
+++ b/src/__tests__/hooks/useTimelineData.fetch.test.ts
@@ -29,12 +29,27 @@ describe('useTimelineData', () => {
           const { id, token } = JSON.parse(data) as { id: string; token: number };
           if (id === 'HEAD') {
             messageHandler?.(
-              new MessageEvent('message', { data: JSON.stringify({ counts: linesSecond, commits, token }) }),
+              new MessageEvent('message', {
+                data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
+              }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', {
+                data: JSON.stringify({ type: 'data', counts: linesSecond, commits, token }),
+              }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           } else {
             const counts = id === 'c2' ? linesFirst : linesSecond;
             messageHandler?.(
-              new MessageEvent('message', { data: JSON.stringify({ counts, token }) }),
+              new MessageEvent('message', {
+                data: JSON.stringify({ type: 'data', counts, token, commits: [] }),
+              }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           }
         }),

--- a/src/__tests__/hooks/useTimelineData.outdated.test.ts
+++ b/src/__tests__/hooks/useTimelineData.outdated.test.ts
@@ -30,21 +30,29 @@ describe('useTimelineData', () => {
           const { id, token } = JSON.parse(data) as { id: string; token: number };
           if (id === 'HEAD') {
             messageHandler?.(
-              new MessageEvent('message', { data: JSON.stringify({ counts: linesSecond, commits, token }) }),
+              new MessageEvent('message', { data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }) }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesSecond, commits, token }) }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           } else if (id === 'c2') {
             resolveFirst = () => {
               messageHandler?.(
-                new MessageEvent('message', {
-                  data: JSON.stringify({ counts: linesFirst, token }),
-                }),
+                new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesFirst, token, commits: [] }) }),
+              );
+              messageHandler?.(
+                new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
               );
             };
           } else {
             messageHandler?.(
-              new MessageEvent('message', {
-                data: JSON.stringify({ counts: linesSecond, token }),
-              }),
+              new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesSecond, token, commits: [] }) }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           }
         }),

--- a/src/__tests__/hooks/useTimelineData.rename.test.ts
+++ b/src/__tests__/hooks/useTimelineData.rename.test.ts
@@ -29,17 +29,31 @@ describe('useTimelineData', () => {
           const { id, token } = JSON.parse(data) as { id: string; token: number };
           if (id === 'HEAD') {
             messageHandler?.(
-              new MessageEvent('message', { data: JSON.stringify({ counts: linesInit, commits, token }) }),
+              new MessageEvent('message', {
+                data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
+              }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesInit, commits, token }) }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           } else if (id === 'c0') {
             messageHandler?.(
-              new MessageEvent('message', { data: JSON.stringify({ counts: linesInit, token }) }),
+              new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesInit, token, commits: [] }) }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           } else {
             messageHandler?.(
               new MessageEvent('message', {
-                data: JSON.stringify({ counts: linesRenamed, renames: { 'b.txt': 'a.txt' }, token }),
+                data: JSON.stringify({ type: 'data', counts: linesRenamed, renames: { 'b.txt': 'a.txt' }, token, commits: [] }),
               }),
+            );
+            messageHandler?.(
+              new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           }
         }),

--- a/src/__tests__/hooks/useTimelineData.sequence.test.ts
+++ b/src/__tests__/hooks/useTimelineData.sequence.test.ts
@@ -39,14 +39,25 @@ describe('useTimelineData', () => {
             if (id === 'HEAD') {
               messageHandler?.(
                 new MessageEvent('message', {
-                  data: JSON.stringify({ counts: lineMap.c3, commits, token }),
+                  data: JSON.stringify({ type: 'range', start: 1000, end: 3000, token }),
                 }),
+              );
+              messageHandler?.(
+                new MessageEvent('message', {
+                  data: JSON.stringify({ type: 'data', counts: lineMap.c3, commits, token }),
+                }),
+              );
+              messageHandler?.(
+                new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
               );
             } else {
               messageHandler?.(
                 new MessageEvent('message', {
-                  data: JSON.stringify({ counts: lineMap[id], token }),
+                  data: JSON.stringify({ type: 'data', counts: lineMap[id], token, commits: [] }),
                 }),
+              );
+              messageHandler?.(
+                new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
               );
             }
           });

--- a/src/__tests__/server/wsCommits.test.ts
+++ b/src/__tests__/server/wsCommits.test.ts
@@ -38,19 +38,19 @@ describe('setupLineCountWs commit range', () => {
       const { port } = server.address() as AddressInfo;
       await expect(
         new Promise<string[]>((resolve, reject) => {
-          const ws = new WebSocket(`ws://localhost:${port}/ws/lines`);
+          const ws = new WebSocket(`ws://localhost:${port}/ws/line-counts`);
           ws.on('open', () => {
             ws.send(JSON.stringify({ id: middle }));
           });
-          ws.on('message', (d) => {
+          ws.on('message', (d: WebSocket.RawData) => {
             const text =
               typeof d === 'string'
                 ? d
                 : Array.isArray(d)
                   ? Buffer.concat(d).toString('utf8')
                   : Buffer.from(d).toString('utf8');
-            const data = JSON.parse(text) as { commits: Array<{ id: string }> };
-            resolve(data.commits.map((c) => c.id));
+            const data = JSON.parse(text) as { type?: string; commits?: Array<{ id: string }> };
+            if (data.type === 'data' && data.commits) resolve(data.commits.map((c) => c.id));
           });
           ws.on('error', reject);
         })

--- a/src/__tests__/server/wsPrepend.test.ts
+++ b/src/__tests__/server/wsPrepend.test.ts
@@ -19,7 +19,7 @@ it('handles upgrades before other listeners', async () => {
 
   await expect(
     new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(`ws://localhost:${port}/ws/lines`);
+      const ws = new WebSocket(`ws://localhost:${port}/ws/line-counts`);
       ws.on('open', () => {
         ws.terminate();
         resolve();

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -15,7 +15,7 @@ interface AppContentProps {
 function AppContent({ playerFactory }: AppContentProps): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
   const [duration, setDuration] = useState(DEFAULT_DURATION);
-  const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
+  const { commits, lineCounts, start, end, ready } = useTimelineData({ timestamp });
   const [playing, setPlaying] = useState(false);
 
   const { togglePlay } = usePlayer({
@@ -35,8 +35,8 @@ function AppContent({ playerFactory }: AppContentProps): React.JSX.Element {
   return (
     <>
       <div id="controls">
-        <PlayPauseButton playing={playing} onToggle={togglePlay} />
-        <SeekBar value={timestamp} min={start} max={end} onChange={setTimestamp} />
+        <PlayPauseButton playing={playing} onToggle={togglePlay} disabled={!ready} />
+        <SeekBar value={timestamp} min={start} max={end} onChange={setTimestamp} disabled={!ready} />
         <label>
           Duration
           <input

--- a/src/client/components/PlayPauseButton.tsx
+++ b/src/client/components/PlayPauseButton.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 export interface PlayPauseButtonProps {
   playing: boolean;
   onToggle: () => void;
+  disabled?: boolean;
 }
 
-export function PlayPauseButton({ playing, onToggle }: PlayPauseButtonProps): React.JSX.Element {
+export function PlayPauseButton({ playing, onToggle, disabled }: PlayPauseButtonProps): React.JSX.Element {
   return (
-    <button type="button" onClick={onToggle}>
+    <button type="button" onClick={onToggle} disabled={disabled}>
       {playing ? 'Pause' : 'Play'}
     </button>
   );

--- a/src/client/components/SeekBar.tsx
+++ b/src/client/components/SeekBar.tsx
@@ -5,9 +5,10 @@ export interface SeekBarProps {
   min: number;
   max: number;
   onChange: (value: number) => void;
+  disabled?: boolean;
 }
 
-export function SeekBar({ value, min, max, onChange }: SeekBarProps): React.JSX.Element {
+export function SeekBar({ value, min, max, onChange, disabled }: SeekBarProps): React.JSX.Element {
   return (
     <input
       type="range"
@@ -15,6 +16,7 @@ export function SeekBar({ value, min, max, onChange }: SeekBarProps): React.JSX.
       min={min}
       max={max}
       onChange={(e) => onChange(Number((e.target as HTMLInputElement).value))}
+      disabled={disabled}
     />
   );
 }


### PR DESCRIPTION
## Summary
- change websocket path to `/ws/line-counts`
- emit range and done messages with type field
- handle new message types in client timeline hook
- disable controls while processing
- adjust tests and mocks for new protocol

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_685171d2cecc832a8cc4eef52af5515a