### PR TITLE
Implement timestamp-based commit selection

### DIFF
--- a/src/__tests__/app/lines.test.ts
+++ b/src/__tests__/app/lines.test.ts
@@ -25,11 +25,13 @@ describe('lines module', () => {
       },
     } as unknown as WebSocket;
     global.WebSocket = jest.fn(() => socket) as unknown as typeof WebSocket;
-    await expect(fetchLineCounts('abc')).resolves.toEqual({
+    await expect(fetchLineCounts(1)).resolves.toEqual({
       counts: [{ file: 'a', lines: 1, added: 0, removed: 0 }],
     });
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ id: 'abc', parent: undefined }));
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ timestamp: 1, parent: undefined }),
+    );
   });
 
   it('throws on empty counts', async () => {
@@ -42,7 +44,7 @@ describe('lines module', () => {
       },
     } as unknown as WebSocket;
     global.WebSocket = jest.fn(() => socket) as unknown as typeof WebSocket;
-    await expect(fetchLineCounts('abc')).rejects.toThrow('No line counts');
+    await expect(fetchLineCounts(1)).rejects.toThrow('No line counts');
   });
 
   it('computes scale with easing', () => {

--- a/src/__tests__/hooks/useTimelineData.dedup.test.ts
+++ b/src/__tests__/hooks/useTimelineData.dedup.test.ts
@@ -23,8 +23,8 @@ describe('useTimelineData', () => {
 
     let messageHandler: ((ev: MessageEvent) => void) | undefined;
     const send = jest.fn((data: string) => {
-      const { id, token } = JSON.parse(data) as { id: string; token: number };
-      if (id === 'HEAD') {
+      const { timestamp, token } = JSON.parse(data) as { timestamp: number; token: number };
+      if (timestamp === Number.MAX_SAFE_INTEGER) {
         messageHandler?.(
           new MessageEvent('message', {
             data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
@@ -39,7 +39,7 @@ describe('useTimelineData', () => {
           new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
         );
       } else {
-        const counts = id === 'c2' ? linesFirst : linesSecond;
+        const counts = timestamp === commits[1]!.timestamp * 1000 ? linesFirst : linesSecond;
         messageHandler?.(
           new MessageEvent('message', {
             data: JSON.stringify({ type: 'data', counts, token, commits: [] }),

--- a/src/__tests__/hooks/useTimelineData.fetch.test.ts
+++ b/src/__tests__/hooks/useTimelineData.fetch.test.ts
@@ -26,8 +26,8 @@ describe('useTimelineData', () => {
       const socket = {
         readyState: 1,
         send: jest.fn((data: string) => {
-          const { id, token } = JSON.parse(data) as { id: string; token: number };
-          if (id === 'HEAD') {
+          const { timestamp, token } = JSON.parse(data) as { timestamp: number; token: number };
+          if (timestamp === Number.MAX_SAFE_INTEGER) {
             messageHandler?.(
               new MessageEvent('message', {
                 data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
@@ -42,7 +42,7 @@ describe('useTimelineData', () => {
               new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
           } else {
-            const counts = id === 'c2' ? linesFirst : linesSecond;
+            const counts = timestamp === commits[1]!.timestamp * 1000 ? linesFirst : linesSecond;
             messageHandler?.(
               new MessageEvent('message', {
                 data: JSON.stringify({ type: 'data', counts, token, commits: [] }),

--- a/src/__tests__/hooks/useTimelineData.outdated.test.ts
+++ b/src/__tests__/hooks/useTimelineData.outdated.test.ts
@@ -27,8 +27,8 @@ describe('useTimelineData', () => {
       const socket = {
         readyState: 1,
         send: jest.fn((data: string) => {
-          const { id, token } = JSON.parse(data) as { id: string; token: number };
-          if (id === 'HEAD') {
+          const { timestamp, token } = JSON.parse(data) as { timestamp: number; token: number };
+          if (timestamp === Number.MAX_SAFE_INTEGER) {
             messageHandler?.(
               new MessageEvent('message', { data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }) }),
             );
@@ -38,7 +38,7 @@ describe('useTimelineData', () => {
             messageHandler?.(
               new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
-          } else if (id === 'c2') {
+          } else if (timestamp === commits[1]!.timestamp * 1000) {
             resolveFirst = () => {
               messageHandler?.(
                 new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesFirst, token, commits: [] }) }),

--- a/src/__tests__/hooks/useTimelineData.rename.test.ts
+++ b/src/__tests__/hooks/useTimelineData.rename.test.ts
@@ -26,8 +26,8 @@ describe('useTimelineData', () => {
       const socket = {
         readyState: 1,
         send: jest.fn((data: string) => {
-          const { id, token } = JSON.parse(data) as { id: string; token: number };
-          if (id === 'HEAD') {
+          const { timestamp, token } = JSON.parse(data) as { timestamp: number; token: number };
+          if (timestamp === Number.MAX_SAFE_INTEGER) {
             messageHandler?.(
               new MessageEvent('message', {
                 data: JSON.stringify({ type: 'range', start: 1000, end: 2000, token }),
@@ -39,7 +39,7 @@ describe('useTimelineData', () => {
             messageHandler?.(
               new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
             );
-          } else if (id === 'c0') {
+          } else if (timestamp === commits[1]!.timestamp * 1000) {
             messageHandler?.(
               new MessageEvent('message', { data: JSON.stringify({ type: 'data', counts: linesInit, token, commits: [] }) }),
             );

--- a/src/__tests__/hooks/useTimelineData.sequence.test.ts
+++ b/src/__tests__/hooks/useTimelineData.sequence.test.ts
@@ -31,12 +31,12 @@ describe('useTimelineData', () => {
       const socket = {
         readyState: 1,
         send: jest.fn((data: string) => {
-          const { id, token } = JSON.parse(data) as {
-            id: keyof typeof lineMap | 'HEAD';
+          const { timestamp, token } = JSON.parse(data) as {
+            timestamp: number;
             token: number;
           };
           callbacks.push(() => {
-            if (id === 'HEAD') {
+            if (timestamp === Number.MAX_SAFE_INTEGER) {
               messageHandler?.(
                 new MessageEvent('message', {
                   data: JSON.stringify({ type: 'range', start: 1000, end: 3000, token }),
@@ -51,9 +51,15 @@ describe('useTimelineData', () => {
                 new MessageEvent('message', { data: JSON.stringify({ type: 'done', token }) }),
               );
             } else {
+              const commitId =
+                timestamp === commits[2]!.timestamp * 1000
+                  ? 'c1'
+                  : timestamp === commits[1]!.timestamp * 1000
+                    ? 'c2'
+                    : 'c3';
               messageHandler?.(
                 new MessageEvent('message', {
-                  data: JSON.stringify({ type: 'data', counts: lineMap[id], token, commits: [] }),
+                  data: JSON.stringify({ type: 'data', counts: lineMap[commitId], token, commits: [] }),
                 }),
               );
               messageHandler?.(

--- a/src/__tests__/server/wsCommits.test.ts
+++ b/src/__tests__/server/wsCommits.test.ts
@@ -30,7 +30,7 @@ describe('setupLineCountWs commit range', () => {
       await git.add({ fs, dir, filepath: 'a.txt' });
       await git.commit({ fs, dir, author, message: 'third' });
       const logs = await git.log({ fs, dir, ref: 'HEAD', depth: 3 });
-      const middle = logs[1]!.oid;
+      const middle = logs[1]!.commit.committer.timestamp * 1000;
       app.set(appSettings.repo.description!, dir);
       app.set(appSettings.branch.description!, 'HEAD');
       setupLineCountWs(app, server);
@@ -40,7 +40,7 @@ describe('setupLineCountWs commit range', () => {
         new Promise<string[]>((resolve, reject) => {
           const ws = new WebSocket(`ws://localhost:${port}/ws/line-counts`);
           ws.on('open', () => {
-            ws.send(JSON.stringify({ id: middle }));
+            ws.send(JSON.stringify({ timestamp: middle }));
           });
           ws.on('message', (d: WebSocket.RawData) => {
             const text =

--- a/src/__tests__/server/wsRangeTimestamp.test.ts
+++ b/src/__tests__/server/wsRangeTimestamp.test.ts
@@ -38,7 +38,7 @@ describe('setupLineCountWs timestamp range', () => {
         new Promise<{ start: number; end: number }>((resolve, reject) => {
           const ws = new WebSocket(`ws://localhost:${port}/ws/line-counts`);
           ws.on('open', () => {
-            ws.send(JSON.stringify({ id: 'HEAD' }));
+            ws.send(JSON.stringify({ timestamp: Number.MAX_SAFE_INTEGER }));
           });
           ws.on('message', (d: WebSocket.RawData) => {
             const text =
@@ -87,8 +87,8 @@ describe('setupLineCountWs timestamp range', () => {
         const received: Array<{ start: number; end: number }> = [];
         let done = 0;
         ws.on('open', () => {
-          ws.send(JSON.stringify({ id: 'HEAD' }));
-          ws.send(JSON.stringify({ id: 'HEAD' }));
+          ws.send(JSON.stringify({ timestamp: Number.MAX_SAFE_INTEGER }));
+          ws.send(JSON.stringify({ timestamp: Number.MAX_SAFE_INTEGER }));
         });
         ws.on('message', (d: WebSocket.RawData) => {
           const text =

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -12,7 +12,7 @@ export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
 };
 
 export const fetchLineCounts = async (
-  commitId: string,
+  timestamp: number,
   baseUrl = '',
   parent?: string,
 ): Promise<LineCountsResult> => {
@@ -20,7 +20,7 @@ export const fetchLineCounts = async (
   return new Promise<LineCountsResult>((resolve, reject) => {
     const socket = new WebSocket(url);
     socket.addEventListener('open', () => {
-      socket.send(JSON.stringify({ id: commitId, parent }));
+      socket.send(JSON.stringify({ timestamp, parent }));
     });
     socket.addEventListener('message', (ev) => {
       const result = JSON.parse(ev.data as string) as


### PR DESCRIPTION
## Summary
- send timestamps instead of commit IDs from the client
- resolve commit IDs on the server using the provided timestamp
- adjust API and websocket handling for the new request format
- update hooks and tests to expect timestamp-based messages

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --omit dev`


------
https://chatgpt.com/codex/tasks/task_e_6851829feee8832a8fd7ac2e23c34b1d