### PR TITLE
feat: websocket timestamp update

### DIFF
--- a/src/__tests__/hooks/useTimelineData.dedup.test.ts
+++ b/src/__tests__/hooks/useTimelineData.dedup.test.ts
@@ -12,7 +12,7 @@ describe('useTimelineData', () => {
     global.WebSocket = originalWebSocket;
   });
 
-  it('sends updates only when commit id changes', async () => {
+  it('sends updates whenever timestamp changes', async () => {
     const commits = [
       { id: 'c1', message: 'a', timestamp: 2 },
       { id: 'c2', message: 'b', timestamp: 1 },
@@ -78,11 +78,11 @@ describe('useTimelineData', () => {
     act(() => {
       rerender({ ts: 1500 });
     });
-    await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(3));
 
     act(() => {
       rerender({ ts: 2000 });
     });
-    await waitFor(() => expect(send).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(4));
   });
 });

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -99,12 +99,12 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
   messageHandlerRef.current = handleMessage;
 
   const update = useCallback(
-    (ts: number, parent?: string) => {
+    (ts: number) => {
       if (lastTimestampRef.current === ts) return;
       token.current += 1;
       lastTimestampRef.current = ts;
       const payload = {
-        data: JSON.stringify({ timestamp: ts, parent, token: token.current }),
+        data: JSON.stringify({ timestamp: ts, token: token.current }),
         token: token.current,
       };
       if (waitingRef.current) {
@@ -154,12 +154,8 @@ export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => 
   useEffect(() => {
     const ts = timestamp === 0 ? start : timestamp;
     if (ts === 0) return;
-    const index = commits.findIndex((c) => c.timestamp * 1000 <= ts);
-    if (index === -1) return;
-    const commit = commits[index]!;
-    const parent = commits[index + 1]?.id;
-    update(commit.timestamp * 1000, parent);
-  }, [timestamp, start, commits, update]);
+    update(ts);
+  }, [timestamp, start, update]);
 
   return { commits, lineCounts, start, end, ready };
 };


### PR DESCRIPTION
## Summary
- send timestamp to websocket whenever it changes
- update dedup test for new behaviour

## Testing
- `npm audit --omit=dev`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852710dd140832a97f43e82251a21d7