### PR TITLE
Fix ws error handler to send typed payload

### DIFF
--- a/src/__tests__/app/lines.test.ts
+++ b/src/__tests__/app/lines.test.ts
@@ -47,6 +47,20 @@ describe('lines module', () => {
     await expect(fetchLineCounts(1)).rejects.toThrow('No line counts');
   });
 
+  it('throws when server reports error', async () => {
+    const socket = {
+      send: jest.fn(),
+      close: jest.fn(),
+      addEventListener: (event: string, cb: (ev: MessageEvent) => void) => {
+        if (event === 'open') cb(new MessageEvent('open'));
+        if (event === 'message')
+          cb(new MessageEvent('message', { data: JSON.stringify({ type: 'error', error: 'boom' }) }));
+      },
+    } as unknown as WebSocket;
+    global.WebSocket = jest.fn(() => socket) as unknown as typeof WebSocket;
+    await expect(fetchLineCounts(1)).rejects.toThrow('boom');
+  });
+
   it('computes scale with easing', () => {
     const scale = computeScale(200, 200, [
       { file: 'a', lines: 1, added: 0, removed: 0 },

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -26,6 +26,11 @@ export const fetchLineCounts = async (
       const result = JSON.parse(ev.data as string) as
         | { type: 'data'; counts: LineCountsResponse['counts']; renames?: Record<string, string> }
         | { type: 'range' | 'done' | 'error'; error?: string };
+      if (result.type === 'error') {
+        socket.close();
+        reject(new Error(result.error ?? 'Unknown error'));
+        return;
+      }
       if (result.type !== 'data') return;
       socket.close();
       if (result.counts.length > 0) {

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -102,7 +102,7 @@ export const setupLineCountWs = (app: express.Application, server: Server) => {
         ws.send(JSON.stringify({ type: 'done', token }));
       } catch (error) {
         ws.send(
-          JSON.stringify({ error: (error as Error).message, token }),
+          JSON.stringify({ type: 'error', error: (error as Error).message, token }),
         );
       } finally {
         processing = false;


### PR DESCRIPTION
## Summary
- include the `type: 'error'` field in ws error payloads
- reject `fetchLineCounts` when receiving an error message
- test the new error handling

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`

------
https://chatgpt.com/codex/tasks/task_e_6852743bc2d0832a8c09e87b5d58b7ca