### PR TITLE
Wrap index test in act

### DIFF
--- a/src/__tests__/app/index.test.tsx
+++ b/src/__tests__/app/index.test.tsx
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { waitFor } from '@testing-library/react';
+import { waitFor, act } from '@testing-library/react';
 import { setupAppTest } from '../helpers/app';
 
 describe('index.tsx', () => {
@@ -26,7 +26,9 @@ describe('index.tsx', () => {
         return instance;
       },
     }));
-    await import('../../client/index');
+    await act(async () => {
+      await import('../../client/index');
+    });
     expect(spy).toHaveBeenCalled();
     await waitFor(() => expect(root.firstChild).toBeTruthy());
   });


### PR DESCRIPTION
## Summary
- use `act` when importing the app entry to avoid uncontrolled updates

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_6852743cde7c832ab74010aecf4a8ecd