### PR TITLE
Fix websocket cleanup in tests

### DIFF
--- a/src/__tests__/server/wsCommits.test.ts
+++ b/src/__tests__/server/wsCommits.test.ts
@@ -50,9 +50,15 @@ describe('setupLineCountWs commit range', () => {
                   ? Buffer.concat(d).toString('utf8')
                   : Buffer.from(d).toString('utf8');
             const data = JSON.parse(text) as { type?: string; commits?: Array<{ id: string }> };
-            if (data.type === 'data' && data.commits) resolve(data.commits.map((c) => c.id));
+            if (data.type === 'data' && data.commits) {
+              ws.terminate();
+              resolve(data.commits.map((c) => c.id));
+            }
           });
-          ws.on('error', reject);
+          ws.on('error', (err) => {
+            ws.terminate();
+            reject(err);
+          });
         })
       ).resolves.toEqual(logs.map((l) => l.oid));
     } finally {

--- a/src/__tests__/server/wsRangeTimestamp.test.ts
+++ b/src/__tests__/server/wsRangeTimestamp.test.ts
@@ -49,10 +49,14 @@ describe('setupLineCountWs timestamp range', () => {
                   : Buffer.from(d).toString('utf8');
             const data = JSON.parse(text) as { type?: string; start?: number; end?: number };
             if (data.type === 'range' && data.start !== undefined && data.end !== undefined) {
+              ws.terminate();
               resolve({ start: data.start, end: data.end });
             }
           });
-          ws.on('error', reject);
+          ws.on('error', (err) => {
+            ws.terminate();
+            reject(err);
+          });
         })
       ).resolves.toEqual({ start: oldest, end: newest });
     } finally {
@@ -103,10 +107,16 @@ describe('setupLineCountWs timestamp range', () => {
           }
           if (data.type === 'done') {
             done += 1;
-            if (done === 2) resolve(received);
+            if (done === 2) {
+              ws.terminate();
+              resolve(received);
+            }
           }
         });
-        ws.on('error', reject);
+        ws.on('error', (err) => {
+          ws.terminate();
+          reject(err);
+        });
       });
       expect(ranges).toEqual([{ start: oldest, end: newest }]);
     } finally {


### PR DESCRIPTION
## Summary
- close websocket connections in server ws tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_685277b8dc6c832aa737db58c623f645