### PR TITLE
codex/ref-eslint-limits

### DIFF
--- a/src/client/components/CharEffects.tsx
+++ b/src/client/components/CharEffects.tsx
@@ -9,10 +9,8 @@ export interface CharEffectsProps {
 export function CharEffects({ effects }: CharEffectsProps): React.JSX.Element {
   const { chars, removeChar } = effects;
 
-  /* eslint-disable no-restricted-syntax */
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const active = React.useRef(new Map<string, HTMLSpanElement>());
-  /* eslint-enable no-restricted-syntax */
+  const containerRef = React.useRef<HTMLDivElement>(null); // eslint-disable-line no-restricted-syntax
+  const active = React.useRef(new Map<string, HTMLSpanElement>()); // eslint-disable-line no-restricted-syntax
 
   React.useEffect(() => {
     const map = active.current;

--- a/src/client/hooks/useFileCircleRefs.ts
+++ b/src/client/hooks/useFileCircleRefs.ts
@@ -1,16 +1,15 @@
 import React, { useCallback } from 'react';
 
 export const useFileCircleRefs = () => {
-  /* eslint-disable no-restricted-syntax */
-  const refs = React.useRef(new Map<string, React.RefObject<HTMLDivElement | null>>());
-  /* eslint-enable no-restricted-syntax */
+  // eslint-disable-next-line no-restricted-syntax
+  const refs = React.useRef(
+    new Map<string, React.RefObject<HTMLDivElement | null>>()
+  );
 
   const getRef = useCallback((file: string): React.RefObject<HTMLDivElement | null> => {
     let ref = refs.current.get(file);
     if (ref === undefined) {
-      /* eslint-disable no-restricted-syntax */
-      ref = React.createRef<HTMLDivElement>();
-      /* eslint-enable no-restricted-syntax */
+      ref = React.createRef<HTMLDivElement>(); // eslint-disable-line no-restricted-syntax
       refs.current.set(file, ref);
     }
     return ref;


### PR DESCRIPTION
## Summary
- scope ref ESLint overrides in FileCircleRefs and CharEffects
- keep <div> ref override

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_685278948734832a98bb3bfd43551a9a