### PR TITLE
codex/extract-hook-logic

### DIFF
--- a/src/client/hooks/useAnimatedNumber.ts
+++ b/src/client/hooks/useAnimatedNumber.ts
@@ -1,61 +1,24 @@
 // eslint-disable-next-line no-restricted-syntax
 import { useCallback, useEffect, useRef, useState } from 'react';
-
-export interface AnimatedNumberOptions {
-  duration?: number;
-  round?: boolean;
-}
+import { AnimatedNumber, AnimatedNumberOptions } from '../logic/AnimatedNumber';
 
 export const useAnimatedNumber = (
   initial: number,
   { duration = 300, round = false }: AnimatedNumberOptions = {},
 ): readonly [number, (n: number) => void] => {
   const [value, setValue] = useState(initial);
-  /* eslint-disable no-restricted-syntax */
-  const fromRef = useRef(initial);
-  const targetRef = useRef(initial);
-  const valueRef = useRef(initial);
-  const startRef = useRef(0);
-  const frameRef = useRef<number | null>(null);
-  /* eslint-enable no-restricted-syntax */
+  // eslint-disable-next-line no-restricted-syntax
+  const controllerRef = useRef<AnimatedNumber | null>(null);
 
-  const step = useCallback(
-    (time: number) => {
-      const linear = Math.min(1, (time - startRef.current) / duration);
-      const progress = 1 - (1 - linear) ** 2;
-      const next = fromRef.current + (targetRef.current - fromRef.current) * progress;
-      setValue(round ? Math.round(next) : next);
-      if (linear < 1) {
-        frameRef.current = requestAnimationFrame(step);
-      } else {
-        fromRef.current = targetRef.current;
-        frameRef.current = null;
-      }
-    },
-    [duration, round],
-  );
+  if (!controllerRef.current) {
+    controllerRef.current = new AnimatedNumber(initial, { duration, round }, setValue);
+  } else {
+    controllerRef.current.updateOptions({ duration, round });
+  }
 
-  useEffect(() => {
-    valueRef.current = value;
-  }, [value]);
+  useEffect(() => () => controllerRef.current?.cancel(), []);
 
-  const animateTo = useCallback(
-    (n: number) => {
-      fromRef.current = valueRef.current;
-      targetRef.current = n;
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-      startRef.current = performance.now();
-      frameRef.current = requestAnimationFrame(step);
-    },
-    [step],
-  );
-
-  useEffect(
-    () => () => {
-      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
-    },
-    [],
-  );
+  const animateTo = useCallback((n: number) => controllerRef.current?.animateTo(n), []);
 
   return [value, animateTo] as const;
 };

--- a/src/client/hooks/useTimelineData.ts
+++ b/src/client/hooks/useTimelineData.ts
@@ -1,163 +1,45 @@
-/* eslint-disable no-restricted-syntax */
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { buildWsUrl } from '../ws';
-import { useWebSocket } from './useWebSocket';
+// eslint-disable-next-line no-restricted-syntax
+import { useEffect, useRef, useState } from 'react';
 import type { Commit, LineCount } from '../types';
-import type { LineCountsResponse } from '../../api/types';
+import { TimelineDataManager, TimelineDataOptions } from '../logic/TimelineDataManager';
 
 
-interface TimelineDataOptions {
-  baseUrl?: string | undefined;
-  timestamp: number;
-}
 
 export const useTimelineData = ({ baseUrl, timestamp }: TimelineDataOptions) => {
-  const [commits, setCommits] = useState<Commit[]>([]);
-  const [start, setStart] = useState(0);
-  const [end, setEnd] = useState(0);
-  const [ready, setReady] = useState(false);
-
-  const [lineCounts, setLineCounts] = useState<LineCount[]>([]);
-  const renameMapRef = useRef<Record<string, string>>({});
-  const token = useRef(0);
-  const processed = useRef(0);
-  const lastTimestampRef = useRef<number | null>(null);
-  const waitingRef = useRef(false);
-  const pendingRef = useRef<{ data: string; token: number } | null>(null);
-  const currentTokenRef = useRef(0);
-  const messageHandlerRef = useRef<(ev: MessageEvent) => void>(() => {});
-
-  const { send, close } = useWebSocket({
-    url: buildWsUrl('/ws/line-counts', baseUrl),
-    onMessage: (ev) => messageHandlerRef.current(ev),
+  const [state, setState] = useState<{ commits: Commit[]; lineCounts: LineCount[]; start: number; end: number; ready: boolean }>({
+    commits: [],
+    lineCounts: [],
+    start: 0,
+    end: 0,
+    ready: false,
   });
+  // eslint-disable-next-line no-restricted-syntax
+  const managerRef = useRef<TimelineDataManager | null>(null);
 
-  const sendMessage = useCallback(
-    (payload: { data: string; token: number }) => {
-      waitingRef.current = true;
-      currentTokenRef.current = payload.token;
-      send(payload.data);
-    },
-    [send],
-  );
-
-  const handleMessage = useCallback(
-    (ev: MessageEvent) => {
-      const payload = JSON.parse(ev.data as string) as {
-        type?: string;
-        token?: number;
-        [key: string]: unknown;
-      };
-    if (payload.type === 'range') {
-      setStart(payload.start as number);
-      setEnd(payload.end as number);
-      return;
-    }
-    if (payload.type === 'done') {
-      if (payload.token === currentTokenRef.current) {
-        waitingRef.current = false;
-        if (pendingRef.current) {
-          const next = pendingRef.current;
-          pendingRef.current = null;
-          setReady(false);
-          sendMessage(next);
-        } else {
-          setReady(true);
-        }
-      }
-      return;
-    }
-    if (payload.type === 'data') {
-      if (Array.isArray(payload.commits)) {
-        setCommits((prev) => {
-          const map = new Map(prev.map((c) => [c.id, c] as const));
-          for (const c of payload.commits as Commit[]) map.set(c.id, c);
-          return Array.from(map.values()).sort((a, b) => b.timestamp - a.timestamp);
-        });
-      }
-      if (
-        payload.token !== undefined &&
-        payload.token > processed.current &&
-        Array.isArray(payload.counts) &&
-        payload.counts.length > 0
-      ) {
-        processed.current = payload.token;
-        if (payload.renames) {
-          for (const [to, from] of Object.entries(payload.renames as Record<string, string>)) {
-            renameMapRef.current[to] = renameMapRef.current[from] ?? from;
-          }
-        }
-        const mapped = (payload.counts as LineCountsResponse['counts']).map((c) => ({
-          ...c,
-          file: renameMapRef.current[c.file] ?? c.file,
-        }));
-        setLineCounts(mapped);
-      }
-    }
-  },
-    [sendMessage],
-  );
-  messageHandlerRef.current = handleMessage;
-
-  const update = useCallback(
-    (ts: number) => {
-      if (lastTimestampRef.current === ts) return;
-      token.current += 1;
-      lastTimestampRef.current = ts;
-      const payload = {
-        data: JSON.stringify({ timestamp: ts, token: token.current }),
-        token: token.current,
-      };
-      if (waitingRef.current) {
-        pendingRef.current = payload;
-      } else {
-        setReady(false);
-        sendMessage(payload);
-      }
-    },
-    [sendMessage],
-  );
+  if (!managerRef.current) {
+    const opts: TimelineDataOptions = { timestamp };
+    if (baseUrl !== undefined) opts.baseUrl = baseUrl;
+    managerRef.current = new TimelineDataManager(opts, setState);
+  } else {
+    const opts: TimelineDataOptions = { timestamp };
+    if (baseUrl !== undefined) opts.baseUrl = baseUrl;
+    managerRef.current.updateOptions(opts);
+  }
 
   useEffect(() => {
-    renameMapRef.current = {};
-    setCommits([]);
-    setLineCounts([]);
-    setStart(0);
-    setEnd(0);
-    setReady(false);
-    waitingRef.current = false;
-    pendingRef.current = null;
-    token.current += 1;
-    processed.current = token.current;
-    lastTimestampRef.current = null;
-    close();
-  }, [baseUrl, close]);
-
-  useEffect(
-    () => () => {
-      close();
-      token.current += 1;
-      processed.current = token.current;
-      lastTimestampRef.current = null;
-      setReady(false);
-      waitingRef.current = false;
-      pendingRef.current = null;
-    },
-    [close],
-  );
-
-  useEffect(() => {
-    if (commits.length === 0) {
-      update(Number.MAX_SAFE_INTEGER);
+    if (state.commits.length === 0) {
+      managerRef.current?.update(Number.MAX_SAFE_INTEGER);
     }
-  }, [commits.length, update]);
+  }, [state.commits.length]);
 
   useEffect(() => {
-    const ts = timestamp === 0 ? start : timestamp;
+    const ts = timestamp === 0 ? state.start : timestamp;
     if (ts === 0) return;
-    if (timestamp === 0 && (waitingRef.current || pendingRef.current)) return;
-    update(ts);
-  }, [timestamp, start, update]);
+    if (timestamp === 0 && (managerRef.current?.isWaiting() || managerRef.current?.hasPending())) return;
+    managerRef.current?.update(ts);
+  }, [timestamp, state.start]);
 
-  return { commits, lineCounts, start, end, ready };
+  useEffect(() => () => managerRef.current?.dispose(), []);
+
+  return state;
 };

--- a/src/client/hooks/useTypewriter.ts
+++ b/src/client/hooks/useTypewriter.ts
@@ -1,31 +1,13 @@
-// eslint-disable-next-line no-restricted-syntax
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Typewriter } from '../logic/Typewriter';
 
 export const useTypewriter = (value: string, delay = 50): string => {
   const [text, setText] = useState(value);
-  /* eslint-disable no-restricted-syntax */
-  const prevRef = useRef(value);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  /* eslint-enable no-restricted-syntax */
 
   useEffect(() => {
-    if (prevRef.current === value) return;
-    let index = 0;
-    prevRef.current = value;
-    setText('');
-
-    const tick = (): void => {
-      index += 1;
-      setText(value.slice(0, index));
-      if (index < value.length) {
-        timerRef.current = setTimeout(tick, delay);
-      }
-    };
-
-    timerRef.current = setTimeout(tick, delay);
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-    };
+    const inst = new Typewriter(delay, setText);
+    inst.start(value);
+    return () => inst.stop();
   }, [value, delay]);
 
   return text;

--- a/src/client/hooks/useWebSocket.ts
+++ b/src/client/hooks/useWebSocket.ts
@@ -1,6 +1,7 @@
-/* eslint-disable no-restricted-syntax */
+// eslint-disable-next-line no-restricted-syntax
 import { useCallback, useEffect, useRef } from 'react';
 import { useLatest } from './useLatest';
+import { WebSocketClient } from '../logic/WebSocketClient';
 
 interface UseWebSocketOptions {
   url: string;
@@ -14,62 +15,21 @@ export const useWebSocket = ({
   reconnectDelay = 1000,
 }: UseWebSocketOptions) => {
   const messageRef = useLatest(onMessage);
-  const socketRef = useRef<WebSocket | null>(null);
-  const reconnectRef = useRef<NodeJS.Timeout | null>(null);
-  const activeRef = useRef(true);
-  const queuedRef = useRef<string | null>(null);
-  const lastRef = useRef<string | null>(null);
+  // eslint-disable-next-line no-restricted-syntax
+  const clientRef = useRef<WebSocketClient | null>(null);
 
-  const sendQueued = useCallback(() => {
-    if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN && queuedRef.current) {
-      socketRef.current.send(queuedRef.current);
-      queuedRef.current = null;
-    }
-  }, []);
+  useEffect(() => {
+    clientRef.current?.dispose();
+    clientRef.current = new WebSocketClient({
+      url,
+      onMessage: (ev) => messageRef.current(ev),
+      reconnectDelay,
+    });
+    return () => clientRef.current?.dispose();
+  }, [url, reconnectDelay, messageRef]);
 
-  const connect = useCallback(() => {
-    if (socketRef.current || !activeRef.current) return;
-    const socket = new WebSocket(url);
-    socket.addEventListener('open', sendQueued);
-    socket.addEventListener('message', (ev) => messageRef.current(ev));
-    const retry = () => {
-      socketRef.current = null;
-      if (activeRef.current) {
-        queuedRef.current = lastRef.current;
-        reconnectRef.current = setTimeout(connect, reconnectDelay);
-      }
-    };
-    socket.addEventListener('close', retry);
-    socket.addEventListener('error', retry);
-    socketRef.current = socket;
-  }, [url, sendQueued, messageRef, reconnectDelay]);
-
-  const send = useCallback(
-    (data: string) => {
-      connect();
-      queuedRef.current = data;
-      lastRef.current = data;
-      sendQueued();
-    },
-    [connect, sendQueued],
-  );
-
-  const close = useCallback(() => {
-    activeRef.current = false;
-    if (reconnectRef.current) clearTimeout(reconnectRef.current);
-    socketRef.current?.close();
-    socketRef.current = null;
-    activeRef.current = true;
-  }, []);
-
-  useEffect(
-    () => () => {
-      activeRef.current = false;
-      if (reconnectRef.current) clearTimeout(reconnectRef.current);
-      socketRef.current?.close();
-    },
-    [],
-  );
+  const send = useCallback((data: string) => clientRef.current?.send(data), []);
+  const close = useCallback(() => clientRef.current?.close(), []);
 
   return { send, close } as const;
 };

--- a/src/client/logic/AnimatedNumber.ts
+++ b/src/client/logic/AnimatedNumber.ts
@@ -1,0 +1,52 @@
+export interface AnimatedNumberOptions {
+  duration?: number;
+  round?: boolean;
+}
+
+export class AnimatedNumber {
+  private from: number;
+  private target: number;
+  private start = 0;
+  private frame: number | null = null;
+  private value: number;
+
+  constructor(initial: number, private opts: Required<AnimatedNumberOptions>, private onChange: (n: number) => void) {
+    this.from = initial;
+    this.target = initial;
+    this.value = initial;
+  }
+
+  updateOptions(opts: AnimatedNumberOptions) {
+    this.opts = { ...this.opts, ...opts };
+  }
+
+  animateTo(n: number) {
+    this.cancel();
+    this.from = this.value;
+    this.target = n;
+    this.start = performance.now();
+    this.frame = requestAnimationFrame(this.step);
+  }
+
+  private step = (time: number) => {
+    const { duration, round } = this.opts;
+    const linear = Math.min(1, (time - this.start) / duration);
+    const progress = 1 - (1 - linear) ** 2;
+    const next = this.from + (this.target - this.from) * progress;
+    this.value = round ? Math.round(next) : next;
+    this.onChange(this.value);
+    if (linear < 1) {
+      this.frame = requestAnimationFrame(this.step);
+    } else {
+      this.from = this.target;
+      this.frame = null;
+    }
+  };
+
+  cancel() {
+    if (this.frame !== null) {
+      cancelAnimationFrame(this.frame);
+      this.frame = null;
+    }
+  }
+}

--- a/src/client/logic/TimelineDataManager.ts
+++ b/src/client/logic/TimelineDataManager.ts
@@ -1,0 +1,155 @@
+import type { Commit, LineCount } from '../types';
+import type { LineCountsResponse } from '../../api/types';
+import { WebSocketClient } from './WebSocketClient';
+import { buildWsUrl } from '../ws';
+
+export interface TimelineDataOptions {
+  baseUrl?: string | undefined;
+  timestamp: number;
+}
+
+interface TimelineDataState {
+  commits: Commit[];
+  lineCounts: LineCount[];
+  start: number;
+  end: number;
+  ready: boolean;
+}
+
+export class TimelineDataManager {
+  state: TimelineDataState = { commits: [], lineCounts: [], start: 0, end: 0, ready: false };
+
+  private renameMap: Record<string, string> = {};
+  private token = 0;
+  private processed = 0;
+  private lastTimestamp: number | null = null;
+  private waiting = false;
+  private pending: { data: string; token: number } | null = null;
+  private currentToken = 0;
+  private socket: WebSocketClient | null = null;
+  private baseUrl?: string | undefined;
+  private timestamp: number;
+
+  isWaiting() {
+    return this.waiting;
+  }
+
+  hasPending() {
+    return this.pending !== null;
+  }
+
+  constructor(opts: TimelineDataOptions, private onChange: (s: TimelineDataState) => void) {
+    this.baseUrl = opts.baseUrl;
+    this.timestamp = opts.timestamp;
+    this.createSocket();
+  }
+
+  updateOptions(opts: TimelineDataOptions) {
+    if (opts.baseUrl !== this.baseUrl) {
+      this.baseUrl = opts.baseUrl;
+      this.reset();
+      this.createSocket();
+    }
+    this.timestamp = opts.timestamp;
+  }
+
+  private createSocket() {
+    if (this.socket) this.socket.dispose();
+    this.socket = new WebSocketClient({
+      url: buildWsUrl('/ws/line-counts', this.baseUrl ?? ''),
+      onMessage: (ev) => this.handleMessage(ev),
+      reconnectDelay: 1000,
+    });
+  }
+
+  private handleMessage(ev: MessageEvent) {
+    const payload = JSON.parse(ev.data as string) as { type?: string; token?: number; [key: string]: unknown };
+    if (payload.type === 'range') {
+      this.state.start = payload.start as number;
+      this.state.end = payload.end as number;
+      this.emit();
+      return;
+    }
+    if (payload.type === 'done') {
+      if (payload.token === this.currentToken) {
+        this.waiting = false;
+        if (this.pending) {
+          const next = this.pending;
+          this.pending = null;
+          this.state.ready = false;
+          this.send(next);
+        } else {
+          this.state.ready = true;
+        }
+        this.emit();
+      }
+      return;
+    }
+    if (payload.type === 'data') {
+      if (Array.isArray(payload.commits)) {
+        const map = new Map(this.state.commits.map((c) => [c.id, c] as const));
+        for (const c of payload.commits as Commit[]) map.set(c.id, c);
+        this.state.commits = Array.from(map.values()).sort((a, b) => b.timestamp - a.timestamp);
+      }
+      if (payload.token !== undefined && payload.token > this.processed && Array.isArray(payload.counts) && payload.counts.length > 0) {
+        this.processed = payload.token;
+        if (payload.renames) {
+          for (const [to, from] of Object.entries(payload.renames as Record<string, string>)) {
+            this.renameMap[to] = this.renameMap[from] ?? from;
+          }
+        }
+        const mapped = (payload.counts as LineCountsResponse['counts']).map((c) => ({
+          ...c,
+          file: this.renameMap[c.file] ?? c.file,
+        }));
+        this.state.lineCounts = mapped;
+      }
+      this.emit();
+    }
+  }
+
+  private emit() {
+    this.onChange({ ...this.state });
+  }
+
+  private send(payload: { data: string; token: number }) {
+    if (!this.socket) return;
+    this.waiting = true;
+    this.currentToken = payload.token;
+    this.socket.send(payload.data);
+  }
+
+  update(timestamp: number) {
+    if (this.lastTimestamp === timestamp) return;
+    this.token += 1;
+    this.lastTimestamp = timestamp;
+    const payload = { data: JSON.stringify({ timestamp, token: this.token }), token: this.token };
+    if (this.waiting) {
+      this.pending = payload;
+    } else {
+      this.state.ready = false;
+      this.send(payload);
+    }
+  }
+
+  reset() {
+    this.renameMap = {};
+    this.state = { commits: [], lineCounts: [], start: 0, end: 0, ready: false };
+    this.waiting = false;
+    this.pending = null;
+    this.token += 1;
+    this.processed = this.token;
+    this.lastTimestamp = null;
+    this.socket?.close();
+  }
+
+  dispose() {
+    this.socket?.dispose();
+    this.token += 1;
+    this.processed = this.token;
+    this.lastTimestamp = null;
+    this.state.ready = false;
+    this.waiting = false;
+    this.pending = null;
+  }
+}

--- a/src/client/logic/Typewriter.ts
+++ b/src/client/logic/Typewriter.ts
@@ -1,0 +1,26 @@
+export class Typewriter {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private index = 0;
+
+  constructor(private delay: number, private onUpdate: (text: string) => void) {}
+
+  start(value: string) {
+    this.stop();
+    this.index = 0;
+    const tick = () => {
+      this.index += 1;
+      this.onUpdate(value.slice(0, this.index));
+      if (this.index < value.length) {
+        this.timer = setTimeout(tick, this.delay);
+      }
+    };
+    this.timer = setTimeout(tick, this.delay);
+  }
+
+  stop() {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/client/logic/WebSocketClient.ts
+++ b/src/client/logic/WebSocketClient.ts
@@ -1,0 +1,60 @@
+interface WebSocketClientOptions {
+  url: string;
+  onMessage: (ev: MessageEvent) => void;
+  reconnectDelay: number;
+}
+
+export class WebSocketClient {
+  private socket: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private active = true;
+  private queued: string | null = null;
+  private last: string | null = null;
+
+  constructor(private opts: WebSocketClientOptions) {}
+
+  private sendQueued() {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN && this.queued) {
+      this.socket.send(this.queued);
+      this.queued = null;
+    }
+  }
+
+  private connect = () => {
+    if (this.socket || !this.active) return;
+    const socket = new WebSocket(this.opts.url);
+    socket.addEventListener('open', this.sendQueued.bind(this));
+    socket.addEventListener('message', this.opts.onMessage);
+    const retry = () => {
+      this.socket = null;
+      if (this.active) {
+        this.queued = this.last;
+        this.reconnectTimer = setTimeout(this.connect, this.opts.reconnectDelay);
+      }
+    };
+    socket.addEventListener('close', retry);
+    socket.addEventListener('error', retry);
+    this.socket = socket;
+  };
+
+  send(data: string) {
+    this.connect();
+    this.queued = data;
+    this.last = data;
+    this.sendQueued();
+  }
+
+  close() {
+    this.active = false;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.socket?.close();
+    this.socket = null;
+    this.active = true;
+  }
+
+  dispose() {
+    this.active = false;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.socket?.close();
+  }
+}


### PR DESCRIPTION
## Summary
- create `src/client/logic` for stateful logic classes
- implement `AnimatedNumber`, `Typewriter`, `WebSocketClient`, and `TimelineDataManager`
- refactor hooks to use the new logic modules
- remove broad ref overrides

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_685278931c00832aa8a5620e906e6785