### PR TITLE
Encapsulate char effect span pool

### DIFF
--- a/src/__tests__/client/charEffectsPool.test.ts
+++ b/src/__tests__/client/charEffectsPool.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import { createCharEffectsPool } from '../../client/charEffectsPool';
+import { MAX_EFFECT_CHARS } from '../../client/constants';
+
+describe('createCharEffectsPool', () => {
+  it('creates isolated span pools', () => {
+    const poolA = createCharEffectsPool();
+    const poolB = createCharEffectsPool();
+
+    const spanA = poolA.acquireSpan();
+    expect(poolA.availableSpans()).toBe(MAX_EFFECT_CHARS - 1);
+    expect(poolB.availableSpans()).toBe(MAX_EFFECT_CHARS);
+
+    if (spanA) {
+      poolA.releaseSpan(spanA);
+    }
+
+    expect(poolA.availableSpans()).toBe(MAX_EFFECT_CHARS);
+  });
+});

--- a/src/client/charEffectsPool.ts
+++ b/src/client/charEffectsPool.ts
@@ -1,29 +1,52 @@
 import { MAX_EFFECT_CHARS } from './constants';
 
-const pool: HTMLSpanElement[] = [];
-let initialized = false;
-
-function ensurePool(): void {
-  if (initialized) return;
-  for (let i = pool.length; i < MAX_EFFECT_CHARS; i += 1) {
-    pool.push(document.createElement('span'));
-  }
-  initialized = true;
+export interface CharEffectsPool {
+  acquireSpan(): HTMLSpanElement | undefined;
+  releaseSpan(el: HTMLSpanElement): void;
+  availableSpans(): number;
 }
 
-export function acquireSpan(): HTMLSpanElement | undefined {
-  ensurePool();
-  return pool.pop();
-}
+export const createCharEffectsPool = (): CharEffectsPool => {
+  const pool: HTMLSpanElement[] = [];
+  let initialized = false;
 
-export function releaseSpan(el: HTMLSpanElement): void {
-  el.className = '';
-  el.textContent = '';
-  el.removeAttribute('style');
-  pool.push(el);
-}
+  const ensurePool = (): void => {
+    if (initialized) return;
+    for (let i = pool.length; i < MAX_EFFECT_CHARS; i += 1) {
+      pool.push(document.createElement('span'));
+    }
+    initialized = true;
+  };
 
-export function availableSpans(): number {
-  ensurePool();
-  return pool.length;
-}
+  return {
+    acquireSpan: (): HTMLSpanElement | undefined => {
+      ensurePool();
+      return pool.pop();
+    },
+    releaseSpan: (el: HTMLSpanElement): void => {
+      el.className = '';
+      el.textContent = '';
+      el.removeAttribute('style');
+      pool.push(el);
+    },
+    availableSpans: (): number => {
+      ensurePool();
+      return pool.length;
+    },
+  };
+};
+
+const defaultPool = createCharEffectsPool();
+
+export const acquireSpan = (
+  ...args: Parameters<CharEffectsPool['acquireSpan']>
+): ReturnType<CharEffectsPool['acquireSpan']> => defaultPool.acquireSpan(...args);
+
+export const releaseSpan = (
+  ...args: Parameters<CharEffectsPool['releaseSpan']>
+): ReturnType<CharEffectsPool['releaseSpan']> => defaultPool.releaseSpan(...args);
+
+export const availableSpans = (
+  ...args: Parameters<CharEffectsPool['availableSpans']>
+): ReturnType<CharEffectsPool['availableSpans']> =>
+  defaultPool.availableSpans(...args);


### PR DESCRIPTION
## Summary
- hide span pool behind `createCharEffectsPool` factory
- export wrappers for default pool functions
- test new pool factory

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_68527f2fe2b4832aa96af5d021f3bb5a