### PR TITLE
support typed arrays in computeScale

### DIFF
--- a/src/__tests__/app/lines.test.ts
+++ b/src/__tests__/app/lines.test.ts
@@ -88,4 +88,11 @@ describe('lines module', () => {
     const scale = computeScale(0, 200, [{ file: 'a', lines: 1, added: 0, removed: 0 }]);
     expect(scale).toBe(0);
   });
+
+  it('handles typed arrays', () => {
+    const typed = new Uint8Array([1, 2, 3]);
+    const scaleFromTyped = computeScale(200, 200, typed);
+    const scaleFromArray = computeScale(200, 200, [1, 2, 3]);
+    expect(scaleFromTyped).toBeCloseTo(scaleFromArray);
+  });
 });

--- a/src/client/scale.ts
+++ b/src/client/scale.ts
@@ -3,24 +3,33 @@ import type { LineCount } from './types';
 export const computeScale = (
   width: number,
   height: number,
-  data: LineCount[],
+  data: ArrayLike<LineCount | number>,
   opts: { linear?: boolean } = {},
 ): number => {
-  if (!Array.isArray(data)) return 0;
   const exp = opts.linear ? 1 : 0.5;
-  const maxLines = data.reduce(
-    (m, d) => Math.max(m, Number.isFinite(d.lines) ? d.lines : 0),
-    1,
-  );
+  const items = Array.from<LineCount | number>(data);
+  let maxLines = 1;
+  for (const d of items) {
+    const lines =
+      typeof d === 'number'
+        ? Number.isFinite(d) ? d : 0
+        : Number.isFinite(d.lines)
+          ? d.lines
+          : 0;
+    if (lines > maxLines) maxLines = lines;
+  }
   const base = Math.min(width, height) / maxLines ** exp;
-  const totalArea = data.reduce(
-    (sum, f) => {
-      const lines = Number.isFinite(f.lines) ? f.lines : 0;
-      const r = ((lines ** exp) * base) / 2;
-      return sum + 4 * r ** 2;
-    },
-    0,
-  );
+  let totalArea = 0;
+  for (const f of items) {
+    const lines =
+      typeof f === 'number'
+        ? Number.isFinite(f) ? f : 0
+        : Number.isFinite(f.lines)
+          ? f.lines
+          : 0;
+    const r = ((lines ** exp) * base) / 2;
+    totalArea += 4 * r ** 2;
+  }
   const ratio = totalArea / (width * height);
   const threshold = 0.1;
   if (!Number.isFinite(ratio) || ratio <= threshold) return base;


### PR DESCRIPTION
## Summary
- make `computeScale` work with numeric typed arrays
- test typed array handling

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68527f359858832a9726feae8b6dab26