### PR TITLE
Extract branch resolver into shared module

### DIFF
--- a/src/__tests__/server/resolveBranch.test.ts
+++ b/src/__tests__/server/resolveBranch.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as git from 'isomorphic-git';
+import { resolveBranch } from '../../server/resolveBranch';
+
+const author = { name: 'a', email: 'a@example.com' };
+
+describe('resolveBranch', () => {
+  it('returns given branch', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    try {
+      await git.init({ fs, dir });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'init' });
+      await git.branch({ fs, dir, ref: 'feature' });
+      await expect(resolveBranch(dir, 'feature')).resolves.toBe('feature');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers main/master/trunk when branch not specified', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    try {
+      await git.init({ fs, dir, defaultBranch: 'main' });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'init' });
+      await git.branch({ fs, dir, ref: 'dev' });
+      await expect(resolveBranch(dir, undefined)).resolves.toBe('main');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns first branch when no preferred names exist', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+    try {
+      await git.init({ fs, dir, defaultBranch: 'x' });
+      await fs.promises.writeFile(path.join(dir, 'a.txt'), '1');
+      await git.add({ fs, dir, filepath: 'a.txt' });
+      await git.commit({ fs, dir, author, message: 'init' });
+      await git.branch({ fs, dir, ref: 'y' });
+      const branches = await git.listBranches({ fs, dir });
+      await expect(resolveBranch(dir, undefined)).resolves.toBe(branches[0]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/server/api-middleware.ts
+++ b/src/server/api-middleware.ts
@@ -5,6 +5,7 @@ import * as git from 'isomorphic-git';
 import fs from 'fs';
 import { getLineCounts, getRenameMap } from './line-counts';
 import { resolveRepoDir, ignorePatterns } from './repo-config';
+import { resolveBranch } from './resolveBranch';
 import type {
   ApiError,
   CommitsResponse,
@@ -36,20 +37,6 @@ const lineCountsResponseSchema = z.object({
 
 const linesQuerySchema = z.object({ parent: z.string().optional() });
 
-const resolveBranch = async (
-  dir: string,
-  inputBranch: string | undefined,
-): Promise<string> => {
-  const branches = await git.listBranches({ fs, dir });
-  let branch = inputBranch;
-  if (!branch) {
-    branch = ['main', 'master', 'trunk'].find((b) => branches.includes(b)) ?? branches[0];
-  }
-  if (!branch) {
-    throw new Error('No branch found.');
-  }
-  return branch;
-};
 
 export const apiMiddleware = express.Router();
 

--- a/src/server/resolveBranch.ts
+++ b/src/server/resolveBranch.ts
@@ -1,0 +1,17 @@
+import * as git from 'isomorphic-git';
+import fs from 'fs';
+
+export const resolveBranch = async (
+  dir: string,
+  inputBranch: string | undefined,
+): Promise<string> => {
+  const branches = await git.listBranches({ fs, dir });
+  let branch = inputBranch;
+  if (!branch) {
+    branch = ['main', 'master', 'trunk'].find((b) => branches.includes(b)) ?? branches[0];
+  }
+  if (!branch) {
+    throw new Error('No branch found.');
+  }
+  return branch;
+};

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import * as git from 'isomorphic-git';
 import { getLineCounts, getRenameMap } from './line-counts';
 import { repoDir, ignorePatterns } from './repo-config';
+import { resolveBranch } from './resolveBranch';
 import { appSettings } from './app-settings';
 
 export interface LineCountsRequest {
@@ -47,9 +48,10 @@ export const setupLineCountWs = (app: express.Application, server: Server) => {
       try {
         const dir = repoDir(app);
         const ignore = ignorePatterns(app);
-        const branch =
-          (app.get(appSettings.branch.description!) as string | undefined) ??
-          'HEAD';
+        const branch = await resolveBranch(
+          dir,
+          app.get(appSettings.branch.description!) as string | undefined,
+        );
         const logs = await git.log({ fs, dir, ref: branch });
         const index = logs.findIndex(
           (c) => c.commit.committer.timestamp * 1000 <= timestamp,


### PR DESCRIPTION
## Summary
- refactor: move resolveBranch into its own module
- reuse resolveBranch in api and websocket servers
- cover resolveBranch with tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`


------
https://chatgpt.com/codex/tasks/task_e_68527f9ae9f4832a894b529373dc7748