### PR TITLE
Add tests for colorForFile and computeScale

### DIFF
--- a/src/__tests__/client/colorForFileConsistency.test.ts
+++ b/src/__tests__/client/colorForFileConsistency.test.ts
@@ -1,0 +1,15 @@
+import { colorForFile, fileColors } from '../../client/colors';
+
+describe('colorForFile consistency', () => {
+  it('returns the same color for repeated calls with known extensions', () => {
+    Object.keys(fileColors).forEach((ext) => {
+      const name = `file${ext}`;
+      expect(colorForFile(name)).toBe(colorForFile(name));
+    });
+  });
+
+  it('produces different colors for different names with the same extension', () => {
+    const ext = Object.keys(fileColors)[0];
+    expect(colorForFile(`a${ext}`)).not.toBe(colorForFile(`b${ext}`));
+  });
+});

--- a/src/__tests__/client/computeScale.test.ts
+++ b/src/__tests__/client/computeScale.test.ts
@@ -1,0 +1,24 @@
+import { computeScale } from '../../client/scale';
+import type { LineCount } from '../../client/types';
+
+describe('computeScale', () => {
+  const data: LineCount[] = [
+    { file: 'a', lines: 1, added: 0, removed: 0 },
+    { file: 'b', lines: 2, added: 0, removed: 0 },
+  ];
+
+  it('calculates expected scale for nonlinear mode', () => {
+    expect(computeScale(200, 200, data)).toBeCloseTo(71.86, 2);
+  });
+
+  it('supports linear scaling option', () => {
+    expect(computeScale(200, 200, data, { linear: true })).toBeCloseTo(53.18, 2);
+  });
+
+  it('uses minimum dimension when all counts are zero', () => {
+    const zero: LineCount[] = [
+      { file: 'z', lines: 0, added: 0, removed: 0 },
+    ];
+    expect(computeScale(100, 50, zero)).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary
- verify colorForFile gives stable results for known extensions
- ensure computeScale returns expected values

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68527fac8aa4832a893cc5308564d334