### PR TITLE
Refactor buildWsUrl to avoid window access

### DIFF
--- a/src/__tests__/ws/buildWsUrl.test.ts
+++ b/src/__tests__/ws/buildWsUrl.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { buildWsUrl } from '../../client/ws';
+import { buildWsUrl, deriveWsOptions } from '../../client/ws';
 
 describe('buildWsUrl', () => {
   const originalWindow = global.window;
@@ -13,20 +13,20 @@ describe('buildWsUrl', () => {
   });
 
   it('uses ws scheme for http base URLs', () => {
-    const url = buildWsUrl('/ws', 'http://example.com');
+    const url = buildWsUrl('/ws', deriveWsOptions('http://example.com'));
     expect(url).toBe('ws://example.com/ws');
   });
 
   it('uses wss scheme for https base URLs', () => {
-    const url = buildWsUrl('/ws', 'https://secure.com');
+    const url = buildWsUrl('/ws', deriveWsOptions('https://secure.com'));
     expect(url).toBe('wss://secure.com/ws');
   });
 
-  it('defaults to window.location when no base URL is provided', () => {
+  it('uses window.location when no base URL is provided', () => {
     global.window = {
       location: { protocol: 'https:', host: 'my.host:8080' },
     } as unknown as Window & typeof globalThis;
-    const url = buildWsUrl('/ws');
+    const url = buildWsUrl('/ws', deriveWsOptions());
     expect(url).toBe('wss://my.host:8080/ws');
   });
 });

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,6 +1,6 @@
 import type { Commit, LineCountsResult } from './types';
 import type { ApiError, CommitsResponse, LineCountsResponse } from '../api/types';
-import { buildWsUrl } from './ws';
+import { buildWsUrl, deriveWsOptions } from './ws';
 
 export const fetchCommits = async (baseUrl = ''): Promise<Commit[]> => {
   const response = await fetch(`${baseUrl}/api/commits`);
@@ -16,7 +16,7 @@ export const fetchLineCounts = async (
   baseUrl = '',
   parent?: string,
 ): Promise<LineCountsResult> => {
-  const url = buildWsUrl('/ws/line-counts', baseUrl);
+  const url = buildWsUrl('/ws/line-counts', deriveWsOptions(baseUrl));
   return new Promise<LineCountsResult>((resolve, reject) => {
     const socket = new WebSocket(url);
     socket.addEventListener('open', () => {

--- a/src/client/logic/TimelineDataManager.ts
+++ b/src/client/logic/TimelineDataManager.ts
@@ -1,7 +1,7 @@
 import type { Commit, LineCount } from '../types';
 import type { LineCountsResponse } from '../../api/types';
 import { WebSocketClient } from './WebSocketClient';
-import { buildWsUrl } from '../ws';
+import { buildWsUrl, deriveWsOptions } from '../ws';
 
 export interface TimelineDataOptions {
   baseUrl?: string | undefined;
@@ -56,7 +56,7 @@ export class TimelineDataManager {
   private createSocket() {
     if (this.socket) this.socket.dispose();
     this.socket = new WebSocketClient({
-      url: buildWsUrl('/ws/line-counts', this.baseUrl ?? ''),
+      url: buildWsUrl('/ws/line-counts', deriveWsOptions(this.baseUrl ?? '')),
       onMessage: (ev) => this.handleMessage(ev),
       reconnectDelay: 1000,
     });

--- a/src/client/ws.ts
+++ b/src/client/ws.ts
@@ -1,12 +1,21 @@
-export const buildWsUrl = (path: string, baseUrl = ''): string => {
+export interface WsOptions {
+  origin: string;
+  secure: boolean;
+}
+
+export const deriveWsOptions = (baseUrl = ''): WsOptions => {
   const secure = baseUrl
     ? baseUrl.startsWith('https')
     : typeof window !== 'undefined' && window.location.protocol === 'https:';
-  const protocol = secure ? 'wss' : 'ws';
   const origin = baseUrl
     ? baseUrl.replace(/^https?:\/\//, '')
     : typeof window !== 'undefined'
       ? window.location.host
       : '';
+  return { origin, secure };
+};
+
+export const buildWsUrl = (path: string, { origin, secure }: WsOptions): string => {
+  const protocol = secure ? 'wss' : 'ws';
   return `${protocol}://${origin}${path}`;
 };


### PR DESCRIPTION
## Summary
- add `deriveWsOptions` helper
- accept `{origin, secure}` in `buildWsUrl`
- update API and TimelineDataManager to use new helper
- adjust tests for new API

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm audit --production`


------
https://chatgpt.com/codex/tasks/task_e_68527f2a6144832a991a09440b56e50e