### PR TITLE
Fix seek bar state and commit log layout

### DIFF
--- a/src/__tests__/app/appHideBeforeReady.test.tsx
+++ b/src/__tests__/app/appHideBeforeReady.test.tsx
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { App } from '../../client/App';
+import { setupAppTest } from '../helpers/app';
+
+const commits = [
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
+];
+
+describe('App hides UI until timeline ready', () => {
+  let restore: () => void;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    restore = setupAppTest({ commits, doneDelay: 100 });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    restore();
+  });
+
+  it('renders loading placeholder before initial data', () => {
+    const { container } = render(<App />);
+    expect(container.textContent).toContain('Loading timeline...');
+  });
+
+  it('shows timestamp after data arrives', async () => {
+    const { container } = render(<App />);
+    jest.advanceTimersByTime(100);
+    await waitFor(() =>
+      expect(container.querySelector('#timestamp')).not.toBeNull(),
+    );
+  });
+});

--- a/src/__tests__/app/appSeekBarEnabledDuringPlay.test.tsx
+++ b/src/__tests__/app/appSeekBarEnabledDuringPlay.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, waitFor, fireEvent, act } from '@testing-library/react';
+import { App } from '../../client/App';
+import { setupAppTest } from '../helpers/app';
+
+const commits = [
+  { id: 'n', message: 'new', timestamp: 2 },
+  { id: 'o', message: 'old', timestamp: 1 },
+];
+
+describe('App seek bar enabled during play', () => {
+  const originalRaf = global.requestAnimationFrame;
+  let restore: () => void;
+  let now = 0;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    restore = setupAppTest({ commits, doneDelay: 100 });
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    global.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      return setTimeout(() => {
+        now += 50;
+        cb(now);
+      }, 0) as unknown as number;
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    (performance.now as jest.Mock).mockRestore();
+    global.requestAnimationFrame = originalRaf;
+    jest.useRealTimers();
+    restore();
+  });
+
+  it('does not disable the seek bar while awaiting data', async () => {
+    const { container } = render(<App />);
+    await waitFor(() =>
+      expect(container.querySelectorAll('#commit-log li').length).toBeGreaterThan(0),
+    );
+    const range = container.querySelector('input[type="range"]') as HTMLInputElement;
+    const button = container.querySelector('#controls button') as HTMLButtonElement;
+    await waitFor(() => expect(range.disabled).toBe(false));
+
+    fireEvent.click(button); // play
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(range.disabled).toBe(false);
+  });
+});

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -15,7 +15,7 @@ interface AppContentProps {
 function AppContent({ playerFactory }: AppContentProps): React.JSX.Element {
   const [timestamp, setTimestamp] = useState(0);
   const [duration, setDuration] = useState(DEFAULT_DURATION);
-  const { commits, lineCounts, start, end, ready } = useTimelineData({ timestamp });
+  const { commits, lineCounts, start, end } = useTimelineData({ timestamp });
   const [playing, setPlaying] = useState(false);
 
   const { togglePlay } = usePlayer({
@@ -32,11 +32,25 @@ function AppContent({ playerFactory }: AppContentProps): React.JSX.Element {
     setTimestamp(start);
   }, [start, end]);
 
+  if (commits.length === 0) {
+    return <div>Loading timeline...</div>;
+  }
+
   return (
     <>
       <div id="controls">
-        <PlayPauseButton playing={playing} onToggle={togglePlay} disabled={!ready} />
-        <SeekBar value={timestamp} min={start} max={end} onChange={setTimestamp} disabled={!ready} />
+        <PlayPauseButton
+          playing={playing}
+          onToggle={togglePlay}
+          disabled={commits.length === 0}
+        />
+        <SeekBar
+          value={timestamp}
+          min={start}
+          max={end}
+          onChange={setTimestamp}
+          disabled={commits.length === 0}
+        />
         <label>
           Duration
           <input
@@ -44,13 +58,19 @@ function AppContent({ playerFactory }: AppContentProps): React.JSX.Element {
             type="number"
             min="1"
             value={duration}
-            onChange={e => setDuration(Number((e.target as HTMLInputElement).value))}
+            onChange={e =>
+              setDuration(Number((e.target as HTMLInputElement).value))
+            }
           />
         </label>
       </div>
       <div id="timestamp">{new Date(timestamp).toLocaleString()}</div>
       <FileCircleSimulation data={lineCounts} />
-      <CommitLog commits={commits} timestamp={timestamp} onTimestampChange={setTimestamp} />
+      <CommitLog
+        commits={commits}
+        timestamp={timestamp}
+        onTimestampChange={setTimestamp}
+      />
     </>
   );
 }

--- a/src/client/components/CommitLog.tsx
+++ b/src/client/components/CommitLog.tsx
@@ -56,7 +56,7 @@ export const CommitLog = ({ commits, timestamp, onTimestampChange, visible = 15 
     }
     setOffset(nextOffset);
     if (index === 0) container.dispatchEvent(new Event('end'));
-  }, [timestamp, index, commits, containerRef]);
+  }, [timestamp, index, commits, containerRef, size.height]);
 
   return (
     // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
## Summary
- keep UI hidden until data arrives
- allow playback interaction while data is loading
- keep commit log spacing consistent when container resizes
- test that seek bar stays enabled during playback
- test that timeline isn't shown until ready

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_68528357de38832a81c7128cb0c79fcf